### PR TITLE
builddep: added usage & summary, and fixed some PEP8 issues

### DIFF
--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -22,9 +22,15 @@ import dnf
 import dnf.cli
 import dnf.exceptions
 import functools
+import gettext
 import logging
 import os
 import rpm
+
+# setup translation for plugin
+t = gettext.translation('dnf-plugins-core', fallback=True)
+_ = t.ugettext
+
 
 logger = logging.getLogger('dnf.plugin')
 
@@ -58,8 +64,8 @@ class sink_rpm_logging(object):
 class BuildDepCommand(dnf.cli.Command):
 
     aliases = ('builddep',)
-    summary = "Install build dependencies for .src.rpm or .spec file"
-    usage = "[PACKAGE.src.rpm|PACKAGE.spec]"
+    summary = _("Install build dependencies for .src.rpm or .spec file")
+    usage = _("[PACKAGE.src.rpm|PACKAGE.spec]")
 
     @staticmethod
     def _rpm_dep2reldep_str(rpm_dep):
@@ -80,7 +86,7 @@ class BuildDepCommand(dnf.cli.Command):
         try:
             spec = rpm.spec(spec_fn)
         except ValueError as e:
-            msg = "Failed to open: '%s', not a valid spec file." % spec_fn
+            msg = _("Failed to open: '%s', not a valid spec file.") % spec_fn
             raise dnf.exceptions.Error(msg)
         for dep in rpm.ds(spec.sourceHeader, 'requires'):
             reldep_str = self._rpm_dep2reldep_str(dep)


### PR DESCRIPTION
Output:

```
$ dnf help builddep
builddep [PACKAGE.src.rpm|PACKAGE.spec]

Install build dependencies for .src.rpm or .spec file
```

```
$ dnf help
..
..
List of Plugin Commands

builddep               Install build dependencies for .src.rpm or .spec file
copr                   Interact with Copr repositories.
```
