### PR TITLE
generate-completion-cache: fix shared lib name

### DIFF
--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -13,7 +13,7 @@
 # Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 # 02110-1301, USA.
 
-from dnfplugins import logger
+from dnfpluginscore import logger
 
 import dnf
 import os.path


### PR DESCRIPTION
looks like I missed a plugin, when renaming shared lib to dnfpluginscore.
I have rechecked all other plugins, they seams to be ok.
