### PR TITLE
debuginfo-install: fix logger debug messages

### DIFF
--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -112,5 +112,5 @@ class DebuginfoInstallCommand(dnf.cli.Command):
             repo = repos[repoid]
             for r in self.base.repos:
                 if r == di:
-                    self.cli.logger.debug(_("enabling {}").format(id))
+                    self.cli.logger.debug(_("enabling {}").format(di))
                     self.base.repos[r].enable()


### PR DESCRIPTION
When we trying to install debuginfo rpms I want to log all enabling
repos, but there typo. `format(id)` should be `format(di)`.

```
[cutted]
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
enabling <built-in function id>
```

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
