### PR TITLE
debuginfo-install: doesn't install latest pkgs (RhBug: 1096507)

### DIFF
--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -94,9 +94,9 @@ class DebuginfoInstallCommand(dnf.cli.Command):
                 for p in provides:
                     pkgs = self.packages_installed.filter(name=p.name)
                     if not pkgs:
-                        pkgs = self.packages_installed.filter(name=p.name)
+                        pkgs = self.packages_available.filter(name=p.name)
                     for pkg in pkgs:
-                        self._di_install(p)
+                        self._di_install(pkg)
 
     def _enable_debug_repos(self):
         repos = {}


### PR DESCRIPTION
This is caused because I've installed 'p' (current provider), but we
need to install 'pkg', which correctly throw installed and available
packages.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1096507
Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
