### PR TITLE
copr: remove repofile if failed to enable repo

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -207,6 +207,7 @@ Do you want to continue? [y/N]: """)
         try:
             ug.urlgrab(cls.copr_url + api_path, filename=repo_filename)
         except grabber.URLGrabError as e:
+            cls._remove_repo(repo_filename)
             raise dnf.exceptions.Error(str(e))
 
     @classmethod


### PR DESCRIPTION
If we trying to enable repo - it trying to download and creating
repofile, but when it's failed (generally Copr repo doesn't exist) -
it's not deleting this repofile.
