### PR TITLE
copr: check for 'ok' in 'output' for json data (RhBug:1134378)

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -127,6 +127,7 @@ Do you want to continue? [y/N]: """)
                 raise dnf.exceptions.Error(
                     _("Can't parse repositories for username '{}'.")
                     .format(project_name))
+            self._check_json_output(json_parse)
             section_text = _("List of {} coprs").format(project_name)
             self._print_match_section(section_text)
             i = 0
@@ -149,6 +150,7 @@ Do you want to continue? [y/N]: """)
                 json_parse = json.loads(res.read())
             except ValueError:
                 raise dnf.exceptions.Error(_("Can't parse search for '{}'.").format(project_name))
+            self._check_json_output(json_parse)
             section_text = _("Matched: {}").format(project_name)
             self._print_match_section(section_text)
             i = 0
@@ -251,6 +253,11 @@ Do you want to continue? [y/N]: """)
                 "Something went wrong:\n {0}\n".format(output["error"])))
             return
         return output
+
+    @classmethod
+    def _check_json_output(cls, json):
+        if json["output"] != "ok":
+            raise dnf.exceptions.Error("{}".format(json["error"]))
 
 
 class Playground(dnf.Plugin):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/bin/dnf", line 36, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 182, in user_main
    errcode = main(args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 84, in main
    return _main(base, args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 134, in _main
    cli.run()
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 1072, in run
    return self.command.run(self.base.extcmds)
  File "/usr/lib/python2.7/site-packages/dnf-plugins/copr.py", line 147, in run
    while i < len(json_parse["repos"]):
KeyError: 'repos'
```

Now we introduce internal function to check 'output' field in json
output. If it is not 'ok', then raise exception with 'error' field in
json.

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1134378
