### PR TITLE
New version: 0.1.3

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,18 @@ Core DNF Plugins Release Notes
 .. contents::
 
 =====================
+ 0.1.3 Release Notes
+=====================
+
+Added info switch to :ref:`repoquery <info_repoquery-label>`
+
+Bugs fixed in 0.1.3:
+
+* :rhbug:`1135984`
+* :rhbug:`1134378`
+* :rhbug:`1123886`
+
+=====================
  0.1.2 Release Notes
 =====================
 

--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -63,6 +63,8 @@ The following are mutually exclusive, i.e. at most one can be specified. If no q
 ``--conflicts``
     Display capabilities that the package conflicts with. Same as ``--qf "%{conflicts}``.
 
+.. _info_repoquery-label:
+
 ``-i, --info``
     Show detailed information about the package.
 

--- a/doc/summaries_cache
+++ b/doc/summaries_cache
@@ -30,5 +30,17 @@
     [
         1118809, 
         "[abrt] dnf: generate_completion_cache.py:55:sack:UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 22: ordinal not in range(128)"
+    ], 
+    [
+        1135984, 
+        "rfe: add repoquery -i support"
+    ], 
+    [
+        1134378, 
+        "[abrt] dnf: copr.py:147:run:KeyError: 'repos'"
+    ], 
+    [
+        1123886, 
+        "[abrt] dnf: i18n.py:138:_exact_width_char:TypeError: must be unicode, not str"
     ]
 ]

--- a/package/dnf-plugins-core.spec
+++ b/package/dnf-plugins-core.spec
@@ -2,7 +2,7 @@
 %global dnf_version 0.5.3
 
 Name:		dnf-plugins-core
-Version:	0.1.2
+Version:	0.1.3
 Release:	1%{?dist}
 Summary:	Core Plugins for DNF
 Group:		System Environment/Base


### PR DESCRIPTION
build will come later. acls is unreachable now and I don't have a permission for dnf-plugins-core.
