### PR TITLE
kickstart: fix installing groups after API change (RhBug:1138414)

### DIFF
--- a/plugins/kickstart.py
+++ b/plugins/kickstart.py
@@ -96,9 +96,13 @@ class KickstartCommand(dnf.cli.Command):
         group_names = [group.name for group in packages.groupList]
 
         if group_names:
+            self.base.fill_sack()
             self.base.read_comps()
         try:
-            self.base.install_grouplist(group_names)
+            for group in group_names:
+                grp = self.base.comps.group_by_pattern(group)
+                if grp:
+                    self.base.group_install(grp, "default")
         except dnf.exceptions.Error:
             are_groups_installed = False
         else:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/bin/dnf", line 36, in <module>
    main.user_main(sys.argv[1:], exit_code=True)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 182, in
user_main
    errcode = main(args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 84, in
main
    return _main(base, args)
  File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 134, in
_main
    cli.run()
  File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 1072, in
run
    return self.command.run(self.base.extcmds)
  File "/usr/lib/python2.7/site-packages/dnf-plugins/kickstart.py", line
101, in run
    self.base.install_grouplist(group_names)
AttributeError: 'BaseCli' object has no attribute 'install_grouplist'
```

API reference doesn't have `base.install_grouplist`, but we have
`base.group_install`. let's fix it!

Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1138414
