### PR TITLE
generate_completion_cache: use sqlite instead of text files

### DIFF
--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -55,7 +55,7 @@ class BashCompletionCache(dnf.Plugin):
                     cur.execute(
                         "create table if not exists available (pkg TEXT)")
                     cur.execute(
-                        "create unique index if not exists"
+                        "create unique index if not exists "
                         "pkg_available ON available(pkg)")
                     cur.execute("delete from available")
                     avail_pkgs = self.base.sack.query().available()
@@ -75,7 +75,7 @@ class BashCompletionCache(dnf.Plugin):
                 cur = conn.cursor()
                 cur.execute("create table if not exists installed (pkg TEXT)")
                 cur.execute(
-                    "create unique index if not exists"
+                    "create unique index if not exists "
                     "pkg_installed ON installed(pkg)")
                 cur.execute("delete from installed")
                 inst_pkgs = self.base.sack.query().installed()


### PR DESCRIPTION
This will really increase performace for bash-completion.

```
$ time sqlite3 packages.db "select pkg from available WHERE pkg LIKE \"tex%\";"
real    0m0.018s
user    0m0.008s
sys    0m0.010s
```

```
$ time grep -E ^tex /var/cache/dnf/available.cache
real    0m0.112s
user    0m0.017s
sys    0m0.043s
```

Signed-off-by: Igor Gnatenko i.gnatenko.brain@gmail.com
