### PR TITLE
debuginfo-install: fix handling of subpackages with non-zero epoch

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,5 +3,6 @@ Igor Gnatenko <i.gnatenko.brain@gmail.com>
 Jan Silhan <jsilhan@redhat.com>
 Miroslav Suchý <msuchy@redhat.com>
 Parag Nemade <pnemade@redhat.com>
+Petr Špaček <pspacek@redhat.com>
 Radek Holy <rholy@redhat.com>
 Tim Lauridsen <timlau@fedoraproject.org>

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -111,6 +111,7 @@ class DebuginfoInstallCommand(dnf.cli.Command):
 
     def _di_install(self, package, require):
         srcname = self._pkgname_src(package)
+        dbgname = self._pkgname_dbg(package)
         if srcname in self.done \
                 or require in self.done \
                 or package in self.rejected:
@@ -119,24 +120,16 @@ class DebuginfoInstallCommand(dnf.cli.Command):
             self.done.append(srcname)
             if require:
                 self.done.append(require)
-            if "-debuginfo" in srcname:
-                di = "{0}-{1}:{2}-{3}.{4}".format(
-                    srcname,
-                    package.epoch,
-                    package.version,
-                    package.release,
-                    package.arch)
-            else:
-                di = "{0}-debuginfo-{1}:{2}-{3}.{4}".format(
-                    srcname,
-                    package.epoch,
-                    package.version,
-                    package.release,
-                    package.arch)
+            di = "{0}-{1}:{2}-{3}.{4}".format(
+                dbgname,
+                package.epoch,
+                package.version,
+                package.release,
+                package.arch)
             self.base.install(di)
         else:
             if self._is_available(package, False):
-                di = "{0}-debuginfo.{1}".format(srcname, package.arch)
+                di = "{0}.{1}".format(dbgname, package.arch)
                 self.base.install(di)
                 self.done.append(srcname)
                 if require:

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -2,6 +2,7 @@
 # Install the debuginfo of packages and their dependencies to debug this package.
 #
 # Copyright (C) 2014 Igor Gnatenko
+# Copyright (C) 2014 Red Hat
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -72,13 +72,13 @@ class DebuginfoInstallCommand(dnf.cli.Command):
     def _pkgname(package):
         return package.sourcerpm.replace("-{}.src.rpm".format(package.evr), "")
 
-    def _is_available(self, package, flag):
+    def _is_available(self, package, match_evra):
         pkgname = self._pkgname(package)
         if "-debuginfo" in package.name:
             name = pkgname
         else:
             name = "{}-debuginfo".format(pkgname)
-        if flag:
+        if match_evra:
             avail = self.packages_available.filter(
                 name="{}".format(name),
                 epoch=int(package.epoch),
@@ -90,7 +90,7 @@ class DebuginfoInstallCommand(dnf.cli.Command):
                 name="{}".format(name),
                 arch=str(package.arch))
         if len(avail) != 0:
-            if flag:
+            if match_evra:
                 return self.packages_available.filter(
                     name="{}".format(name.replace("-debuginfo", "")),
                     epoch=int(package.epoch),

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -72,7 +72,10 @@ class DebuginfoInstallCommand(dnf.cli.Command):
     @staticmethod
     def _pkgname_src(package):
         """get source package name without debuginfo suffix, e.g. krb5"""
-        return package.sourcerpm.replace("-{}.src.rpm".format(package.evr), "")
+        name = package.sourcerpm.replace("-{}.src.rpm".format(package.evr), "")
+        # source package names usually do not contain epoch, handle both cases
+        return name.replace("-{0.version}-{0.release}.src.rpm".format(package),
+                            "")
 
     @classmethod
     def _pkgname_dbg(cls, package):


### PR DESCRIPTION
You can test is e.g. with package bind-utils or java-1.8.0-openjdk-headless (Fedora 21).