### PR TITLE
builddep: Support defining macros for parsing spec files

### DIFF
--- a/doc/builddep.rst
+++ b/doc/builddep.rst
@@ -17,6 +17,16 @@ Arguments
 ``<file>``
     The path to .src.rpm, .nosrc.rpm or .spec file, to read the needed build requirements from.
 
+-------
+Options
+-------
+
+``--help-cmd``
+    Show this help.
+
+``-D <macro expr>, --define <macro expr>``
+    Define the RPM macro named `macro` to the value `expr` when parsing spec files.
+
 --------
 Examples
 --------
@@ -26,3 +36,6 @@ Examples
 
 ``dnf builddep foobar-1.0-1.src.rpm``
     Install the needed build requirements, defined in the foobar-1.0-1.src.rpm file.
+
+``dnf builddep -D 'scl python27' python-foobar.spec``
+    Install the needed build requirements for the python27 SCL version of python-foobar.

--- a/tests/resources/tour.spec
+++ b/tests/resources/tour.spec
@@ -10,6 +10,9 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-hawkey
 Packager: roll up <roll@up.net>
 BuildRequires: emacs-extras
 BuildRequires: emacs-goodies >= 100
+%if 0%{?enable_optional_module}
+BuildRequires: emacs-module
+%endif
 
 %description
 The tour package to test stuff.

--- a/tests/test_builddep.py
+++ b/tests/test_builddep.py
@@ -52,6 +52,14 @@ class BuildDepCommandTest(unittest.TestCase):
             self.assertEqual(base.marked,
                              ['emacs-extras', 'emacs-goodies >= 100'])
 
+    @unittest.skipIf(support.PY3, "rpm.spec not available in Py3")
+    def test_macro(self):
+        with mock.patch('builddep.BuildDepCommand.base', MockBase()) as base:
+            self.cmd.run(('--define', 'enable_optional_module 1', SPEC,))
+            self.assertEqual(base.marked,
+                             ['emacs-extras', 'emacs-goodies >= 100',
+                              'emacs-module'])
+
     def test_configure(self):
         self.cmd.configure(None)
         self.assertTrue(self.cmd.cli.demands.available_repos)


### PR DESCRIPTION
Some spec files allow enabling features by setting RPM macros, like
with the following snippet for example:

    %if 0%{?enable_png}
    BuildRequires:  libpng-devel
    %endif

This change adds an option consistent with RPM commands to define a
macro to use while parsing spec files.  It allows installing
explicitly requested build dependencies for spec files using macros
like the above.

Argparse was added for this option handling.