### PR TITLE
repoquery: Always get latest packages in a query output

### DIFF
--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -193,7 +193,7 @@ class RepoQueryCommand(dnf.cli.Command):
             print(QUERY_TAGS)
             return
 
-        q = self.base.sack.query().available()
+        q = self.base.sack.query().available().latest()
         if opts.key:
             if set(opts.key) & set('*[?'):  # is pattern ?
                 fdict = {'name__glob': opts.key}


### PR DESCRIPTION
Here is the use-case compared with yum's repoquery
[parag@f21 dnf]$ sudo repoquery harfbuzz
harfbuzz-0:0.9.36-1.fc21.i686
harfbuzz-0:0.9.36-1.fc21.x86_64

with the current repoquery plugin
[parag@f21 dnf]$ sudo dnf repoquery harfbuzz
harfbuzz-0:0.9.34-1.fc21.i686
harfbuzz-0:0.9.34-1.fc21.x86_64
harfbuzz-0:0.9.36-1.fc21.i686
harfbuzz-0:0.9.36-1.fc21.x86_64

If used this PR fix then the output will be
[parag@f21 dnf]$ sudo dnf repoquery harfbuzz
harfbuzz-0:0.9.36-1.fc21.i686
harfbuzz-0:0.9.36-1.fc21.x86_64

I can't think any usecase where we need to return all the available builds for any package.

Thanks.