### PR TITLE
repoquery: query should print per package information not all collectively

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 Ales Kozumplik <ales@redhat.com>
 Igor Gnatenko <i.gnatenko.brain@gmail.com>
 Jan Silhan <jsilhan@redhat.com>
+Michal Mraka <michael.mraka@redhat.com>
 Miroslav Suchý <msuchy@redhat.com>
 Parag Nemade <pnemade@redhat.com>
 Petr Špaček <pspacek@redhat.com>

--- a/doc/download.rst
+++ b/doc/download.rst
@@ -42,7 +42,7 @@ Options
     Show this help.
 
 ``--source``
-    Download the source rpm.
+    Download the source rpm. Enables source repositories of all enabled binary repositories.
 
 ``--destdir``
     Download directory, default is the current directory (the directory must exist).

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,21 @@ Core DNF Plugins Release Notes
 .. contents::
 
 =====================
+ 0.1.5 Release Notes
+=====================
+
+:doc:`builddep` accepts also `nosrc.rpm` package.
+
+:doc:`repoquery` adds `--list` switch to show files the package contains.
+
+Bugs fixed in 0.1.5:
+
+* :rhbug:`1187773`
+* :rhbug:`1178239`
+* :rhbug:`1166126`
+* :rhbug:`1155211`
+
+=====================
  0.1.4 Release Notes
 =====================
 

--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -25,7 +25,7 @@ Query package information from Yum repositories.
 Synopsis
 --------
 
-``dnf repoquery [<select-options>] [<query-options>] [<pkg-name>]``
+``dnf repoquery [<select-options>] [<query-options>] [<pkg-spec>]``
 ``dnf repoquery --querytags``
 
 -----------
@@ -38,7 +38,11 @@ Description
 Select Options
 --------------
 
-Together with ``<pkg-name>``, control what packages are displayed in the output. If ``<pkg-name>`` is given, the set of resulting packages is limited to the ones with a matching name (globbing supported), else all packages are considered.
+Together with ``<pkg-spec>``, control what packages are displayed in the output. If ``<pkg-spec>`` is given, the set of resulting packages matching the specification. All packages are considered if no ``<pkg-spec>`` is specified.
+
+``<pkg-spec>``
+    Package specification like: name[-[epoch:]version[-release]][.arch]. See
+    http://dnf.readthedocs.org/en/latest/command_ref.html#specifying-packages
 
 ``--arch <arch>``
     Limit the resulting set only to packages of arch ``<arch>``.

--- a/doc/summaries_cache
+++ b/doc/summaries_cache
@@ -50,5 +50,21 @@
     [
         1144003, 
         "[abrt] dnf: download.py:181:_get_query_source:TypeError: 'NoneType' object has no attribute '__getitem__'"
+    ], 
+    [
+        1187773, 
+        "[abrt] dnf: copr.py:230:_download_repo:NameError: global name 'e' is not defined"
+    ], 
+    [
+        1178239, 
+        "[abrt] dnf: posixpath.py:80:join:UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 23: ordinal not in range(128)"
+    ], 
+    [
+        1166126, 
+        "dnf builddep does not recognize nosrc.rpm packages"
+    ], 
+    [
+        1155211, 
+        "dnf builddep: print what's missing when package not found"
     ]
 ]

--- a/package/dnf-plugins-core.spec
+++ b/package/dnf-plugins-core.spec
@@ -2,7 +2,7 @@
 %{?!dnf_version: %global dnf_version 0.6.3}
 
 Name:		dnf-plugins-core
-Version:	0.1.4
+Version:	0.1.5
 Release:	1%{?dist}
 Summary:	Core Plugins for DNF
 Group:		System Environment/Base

--- a/package/dnf-plugins-core.spec
+++ b/package/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{!?gitrev: %global gitrev c8940d0}
+%{!?gitrev: %global gitrev 351e094}
 %{?!dnf_version: %global dnf_version 0.6.3}
 
 Name:		dnf-plugins-core
@@ -92,6 +92,27 @@ PYTHONPATH=./plugins /usr/bin/nosetests-3.* -s tests/
 %{_mandir}/man8/dnf.plugin.*
 
 %changelog
+
+* Thu Feb 5 2015 Jan Silhan <jsilhan@redhat.com> - 0.1.5-1
+- updated package url (Michael Mraka)
+- also dnf_version could be specified on rpmbuild commandline (Michael Mraka)
+- simple script to build test package (Michael Mraka)
+- let gitrev be specified on rpmbuild commandline (Michael Mraka)
+- assign default GITREV value (Michael Mraka)
+- standard way to find out latest commit (Michael Mraka)
+- debuginfo-install: fix handling of subpackages with non-zero epoch (Petr Spacek)
+- debuginfo-install: Make laywers happier by assigning copyright to Red Hat (Petr Spacek)
+- debuginfo-install: remove dead code uncovered by variable renaming (Petr Spacek)
+- debuginfo-install: clearly separate source and debug package names (Petr Spacek)
+- debuginfo-install: use descriptive parameter name in _is_available() (Petr Spacek)
+- repoquery: add -l option to list files contained in the package (Petr Spacek)
+- 1187773 - replace undefined variable (Miroslav Suchý)
+- download: fixed unicode location error (RhBug:1178239) (Jan Silhan)
+- builddep recognizes nosrc.rpm pkgs (RhBug:1166126) (Jan Silhan)
+- builddep: added nosignatures flag to rpm transaction set (Jan Silhan)
+- builddep: more verbose output of non-matching packages (RhBug:1155211) (Jan Silhan)
+- package: archive script is the same as in dnf (Jan Silhan)
+- spec: exclude __pycache__ dir (Igor Gnatenko)
 
 * Fri Dec 5 2014 Jan Silhan <jsilhan@redhat.com> - 0.1.4-1
 - revert of commit 80ae3f4 (Jan Silhan)

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -30,8 +30,8 @@ import requests
 import urllib
 
 
-yes = set([_('yes'), _('y')])
-no = set([_('no'), _('n'), ''])
+YES = set([_('yes'), _('y')])
+NO = set([_('no'), _('n'), ''])
 
 
 class Copr(dnf.Plugin):
@@ -179,10 +179,10 @@ Do you want to continue? [y/N]: """)
 
         answer = raw_input(question).lower()
         answer = _(answer)
-        while not ((answer in yes) or (answer in no)):
+        while not ((answer in YES) or (answer in NO)):
             answer = raw_input(question).lower()
             answer = _(answer)
-        if answer in yes:
+        if answer in YES:
             return
         else:
             raise dnf.exceptions.Error(_('Safe and good answer. Exiting.'))

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -148,13 +148,15 @@ Do you want to continue? [y/N]: """)
             try:
                 json_parse = json.loads(res.read())
             except ValueError:
-                raise dnf.exceptions.Error(_("Can't parse search for '{}'.").format(project_name))
+                raise dnf.exceptions.Error(_("Can't parse search for '{}'."
+                                            ).format(project_name))
             self._check_json_output(json_parse)
             section_text = _("Matched: {}").format(project_name)
             self._print_match_section(section_text)
             i = 0
             while i < len(json_parse["repos"]):
-                msg = "{0}/{1} : ".format(json_parse["repos"][i]["username"], json_parse["repos"][i]["coprname"])
+                msg = "{0}/{1} : ".format(json_parse["repos"][i]["username"],
+                                          json_parse["repos"][i]["coprname"])
                 desc = json_parse["repos"][i]["description"]
                 if not desc:
                     desc = _("No description given.")
@@ -304,7 +306,8 @@ Do you want to continue? [y/N]: """)
                     self.copr_url, project_name, chroot)
                 req = requests.get(api_url)
                 output2 = self._get_data(req)
-                if output2 and ("output" in output2) and (output2["output"] == "ok"):
+                if (output2 and ("output" in output2)
+                        and (output2["output"] == "ok")):
                     self._download_repo(project_name, repo_filename, chroot)
             except dnf.exceptions.Error:
                 # likely 404 and that repo does not exist

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -258,9 +258,9 @@ Do you want to continue? [y/N]: """)
         return output
 
     @classmethod
-    def _check_json_output(cls, json):
-        if json["output"] != "ok":
-            raise dnf.exceptions.Error("{}".format(json["error"]))
+    def _check_json_output(cls, json_obj):
+        if json_obj["output"] != "ok":
+            raise dnf.exceptions.Error("{}".format(json_obj["error"]))
 
 
 class Playground(dnf.Plugin):

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -132,7 +132,7 @@ Do you want to continue? [y/N]: """)
             i = 0
             while i < len(json_parse["repos"]):
                 msg = "{0}/{1} : ".format(project_name,
-                      json_parse["repos"][i]["name"])
+                                          json_parse["repos"][i]["name"])
                 desc = json_parse["repos"][i]["description"]
                 if not desc:
                     desc = _("No description given")
@@ -294,7 +294,7 @@ Do you want to continue? [y/N]: """)
             raise dnf.cli.CliError(_("Unknown response from server."))
         for repo in output["repos"]:
             project_name = "{0}/{1}".format(repo["username"],
-                repo["coprname"])
+                                            repo["coprname"])
             repo_filename = "/etc/yum.repos.d/_playground_{}.repo" \
                     .format(project_name.replace("/", "-"))
             try:

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -1,6 +1,6 @@
 # supplies the 'copr' command.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -23,6 +23,7 @@ from dnfpluginscore import _, logger
 
 import dnf
 import dnf.cli
+import dnf.subject
 
 
 class DebuginfoInstall(dnf.Plugin):
@@ -62,11 +63,10 @@ class DebuginfoInstallCommand(dnf.cli.Command):
         self.packages = self.base.sack.query()
         self.packages_available = self.packages.available()
         self.packages_installed = self.packages.installed()
-        for pkg in args:
-            pkgs = self.packages_installed.filter(name=pkg)
-            if not pkgs:
-                pkgs = self.packages_available.filter(name=pkg)
-            for pkg in pkgs:
+
+        for pkgspec in args:
+            for pkg in dnf.subject.Subject(pkgspec).get_best_query(
+                    self.cli.base.sack):
                 self._di_install(pkg, None)
 
     @staticmethod

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -38,6 +38,7 @@ class Download(dnf.Plugin):
     name = 'download'
 
     def __init__(self, base, cli):
+        super(Download, self).__init__(base, cli)
         self.base = base
         self.cli = cli
         if self.cli is not None:

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -27,7 +27,6 @@ import dnf.exceptions
 import dnf.i18n
 import dnf.subject
 import dnfpluginscore
-import functools
 import hawkey
 import itertools
 import os
@@ -91,8 +90,8 @@ class DownloadCommand(dnf.cli.Command):
         else:
             dest = dnf.i18n.ucd(os.getcwd())
 
-        move = functools.partial(self._move_package, dest)
-        map(move, locations)
+        for pkg in locations:
+            self._move_package(dest, pkg)
 
     def _download_rpms(self, pkg_specs):
         """Download packages to dnf cache."""

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -158,24 +158,18 @@ class DownloadCommand(dnf.cli.Command):
     def _enable_source_repos(self):
         """Enable source repositories for enabled binary repositories.
 
-        binary repositories will be disabled and the dnf sack will be reloaded
+        Don't disable the binary ones because they can contain SRPMs as well
+        (this applies to COPR and to user-managed repos).
+        The dnf sack will be reloaded.
         """
-        repo_dict = {}
-        # find the source repos for the enabled binary repos
+        # enable the source repos
         for repo in self.base.repos.iter_enabled():
-            source_repo = '%s-source' % repo.id
-            if source_repo in self.base.repos:
-                repo_dict[repo.id] = (repo, self.base.repos[source_repo])
-            else:
-                repo_dict[repo.id] = (repo, None)
-        # disable the binary & enable the source ones
-        for id_ in repo_dict:
-            repo, src_repo = repo_dict[id_]
-            repo.disable()
-            if src_repo:
-                logger.info(_('enabled %s repository'), src_repo.id)
-                src_repo.enable()
-       # reload the sack
+            source_repo_id = '%s-source' % repo.id
+            if source_repo_id in self.base.repos:
+                source_repo = self.base.repos[source_repo_id]
+                logger.info(_('enabled %s repository'), source_repo.id)
+                source_repo.enable()
+        # reload the sack
         self.base.fill_sack()
 
     def _get_query(self, pkg_spec):

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -142,7 +142,8 @@ class DownloadCommand(dnf.cli.Command):
             logger.debug(_('Error in resolve'))
             return []
 
-    def _get_source_packages(self, pkgs):
+    @staticmethod
+    def _get_source_packages(pkgs):
         """Get list of source rpm names for a list of packages."""
         source_pkgs = set()
         for pkg in pkgs:
@@ -196,7 +197,8 @@ class DownloadCommand(dnf.cli.Command):
                      release=nevra.release, arch=nevra.arch)
         return q
 
-    def _move_package(self, target, location):
+    @staticmethod
+    def _move_package(target, location):
         """Move the downloaded package to target."""
         shutil.copy(location, target)
         os.unlink(location)

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -156,7 +156,7 @@ class DownloadCommand(dnf.cli.Command):
             elif pkg.arch == 'src':
                 source_pkgs.add("%s-%s.src.rpm" % (pkg.name, pkg.evr))
             else:
-                logger.info(_("No source rpm definded for %s"), str(pkg))
+                logger.info(_("No source rpm defined for %s"), str(pkg))
         return list(source_pkgs)
 
     def _enable_source_repos(self):

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -173,7 +173,7 @@ class DownloadCommand(dnf.cli.Command):
             repo, src_repo = repo_dict[id_]
             repo.disable()
             if src_repo:
-                logger.info(_('enabled %s repository') % src_repo.id)
+                logger.info(_('enabled %s repository'), src_repo.id)
                 src_repo.enable()
        # reload the sack
         self.base.fill_sack()

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -1,6 +1,6 @@
 # download.py, supplies the 'download' command.
 #
-# Copyright (C) 2013-2014  Red Hat, Inc.
+# Copyright (C) 2013-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -153,6 +153,8 @@ class DownloadCommand(dnf.cli.Command):
                 source_pkgs.add(pkg.sourcerpm)
                 logger.debug('  --> Package : %s Source : %s',
                              str(pkg), pkg.sourcerpm)
+            elif pkg.arch == 'src':
+                source_pkgs.add("%s-%s.src.rpm" % (pkg.name, pkg.evr))
             else:
                 logger.info(_("No source rpm definded for %s"), str(pkg))
         return list(source_pkgs)

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -69,13 +69,15 @@ class DownloadCommand(dnf.cli.Command):
         # You must only add options not used by dnf already
         self.parser = dnfpluginscore.ArgumentParser(self.aliases[0])
         self.parser.add_argument('packages', nargs='+',
-                            help=_('packages to download'))
+                                 help=_('packages to download'))
         self.parser.add_argument("--source", action='store_true',
-                            help=_('download the src.rpm instead'))
-        self.parser.add_argument('--destdir',
-                            help=_('download path, default is current dir'))
-        self.parser.add_argument('--resolve', action='store_true',
-                            help=_('resolve and download needed dependencies'))
+                                 help=_('download the src.rpm instead'))
+        self.parser.add_argument(
+            '--destdir',
+            help=_('download path, default is current dir'))
+        self.parser.add_argument(
+            '--resolve', action='store_true',
+            help=_('resolve and download needed dependencies'))
 
         # parse the options/args
         # list available options/args on errors & exit

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -50,6 +50,11 @@ class DownloadCommand(dnf.cli.Command):
     summary = _('Download package to current directory')
     usage = _('PACKAGE...')
 
+    def __init__(self, cli):
+        super(DownloadCommand, self).__init__(cli)
+        self.opts = None
+        self.parser = None
+
     def configure(self, args):
         # setup sack and populate it with enabled repos
         demands = self.cli.demands

--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -28,6 +28,7 @@ class BashCompletionCache(dnf.Plugin):
     name = 'generate_completion_cache'
 
     def __init__(self, base, cli):
+        super(BashCompletionCache, self).__init__(base, cli)
         self.base = base
         self.cache_file = "/var/cache/dnf/packages.db"
 

--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -60,7 +60,7 @@ class BashCompletionCache(dnf.Plugin):
                     cur.execute("delete from available")
                     avail_pkgs = self.base.sack.query().available()
                     avail_pkgs_insert = [["{}.{}".format(x.name, x.arch)]
-                        for x in avail_pkgs if x.arch != "src"]
+                                         for x in avail_pkgs if x.arch != "src"]
                     cur.executemany("insert or ignore into available values (?)",
                                     avail_pkgs_insert)
                     conn.commit()
@@ -80,7 +80,7 @@ class BashCompletionCache(dnf.Plugin):
                 cur.execute("delete from installed")
                 inst_pkgs = self.base.sack.query().installed()
                 inst_pkgs_insert = [["{}.{}".format(x.name, x.arch)]
-                    for x in inst_pkgs if x.arch != "src"]
+                                    for x in inst_pkgs if x.arch != "src"]
                 cur.executemany("insert or ignore into installed values (?)",
                                 inst_pkgs_insert)
                 conn.commit()

--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -2,6 +2,7 @@
 # generate_completion_cache.py - generate cache for dnf bash completion
 # Copyright © 2013 Elad Alfassa <elad@fedoraproject.org>
 # Copyright (C) 2014 Igor Gnatenko <i.gnatenko.brain@gmail.com>
+# Copyright (C) 2015  Red Hat, Inc.
 
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/ghost.py
+++ b/plugins/ghost.py
@@ -29,6 +29,7 @@ class Ghost(dnf.Plugin):
     name = 'ghost'
 
     def __init__(self, base, cli):
+        super(Ghost, self).__init__(base, cli)
         self.base = base
         self.cli = cli
         if cli is None:

--- a/plugins/ghost.py
+++ b/plugins/ghost.py
@@ -37,7 +37,8 @@ class Ghost(dnf.Plugin):
         else:
             self._out('loaded (with CLI)')
 
-    def _out(self, msg):
+    @staticmethod
+    def _out(msg):
         logger.debug('Ghost plugin: %s', msg)
 
     def config(self):

--- a/plugins/ghost.py
+++ b/plugins/ghost.py
@@ -1,6 +1,6 @@
 # ghost.py, it's a show about nothing.
 #
-# Copyright (C) 2013  Red Hat, Inc.
+# Copyright (C) 2013-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/noroot.py
+++ b/plugins/noroot.py
@@ -1,6 +1,6 @@
 # noroot.py
 #
-# Copyright (C) 2013  Red Hat, Inc.
+# Copyright (C) 2013-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/noroot.py
+++ b/plugins/noroot.py
@@ -19,7 +19,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from dnfpluginscore import logger, _
+from dnfpluginscore import _
 
 import dnf
 import dnf.exceptions

--- a/plugins/noroot.py
+++ b/plugins/noroot.py
@@ -33,6 +33,7 @@ class Noroot(dnf.Plugin):
     name = 'noroot'
 
     def __init__(self, base, cli):
+        super(Noroot, self).__init__(base, cli)
         self.base = base
         self.cli = cli
 

--- a/plugins/protected_packages.py
+++ b/plugins/protected_packages.py
@@ -20,7 +20,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from dnfpluginscore import _, logger
+from dnfpluginscore import _
 
 import dnf
 import dnf.exceptions

--- a/plugins/protected_packages.py
+++ b/plugins/protected_packages.py
@@ -1,7 +1,7 @@
 # protected_packages.py
 # Prevent package removals that could leave the system broken.
 #
-# Copyright (C) 2014  Red Hat, Inc.
+# Copyright (C) 2014-2015  Red Hat, Inc.
 #
 # This copyrighted material is made available to anyone wishing to use,
 # modify, copy, or redistribute it subject to the terms and conditions of

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -24,6 +24,7 @@ from dnfpluginscore import _
 import dnf
 import dnf.cli
 import dnf.exceptions
+import dnf.subject
 import dnfpluginscore
 import functools
 import hawkey
@@ -193,13 +194,13 @@ class RepoQueryCommand(dnf.cli.Command):
             print(QUERY_TAGS)
             return
 
-        q = self.base.sack.query().available()
         if opts.key:
-            if set(opts.key) & set('*[?'):  # is pattern ?
-                fdict = {'name__glob': opts.key}
-            else:  # substring
-                fdict = {'name': opts.key}
-            q = q.filter(hawkey.ICASE, **fdict)
+            q = dnf.subject.Subject(opts.key, ignore_case=True).get_best_query(
+                self.base.sack, with_provides=False)
+        else:
+            q = self.base.sack.query()
+        # do not show packages from @System repo
+        q = q.available()
         if opts.repoid:
             q = q.filter(reponame=opts.repoid)
         if opts.arch:

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -218,7 +218,9 @@ class RepoQueryCommand(dnf.cli.Command):
         for po in query.run():
             try:
                 pkg = PackageWrapper(po)
+                print(po)
                 print(fmt_fn(pkg))
+                print(" ")
             except AttributeError as e:
                 # catch that the user has specified attributes
                 # there don't exist on the dnf Package object.

--- a/scripts/lint
+++ b/scripts/lint
@@ -21,8 +21,9 @@ disable "-d W0141" # used builtin 'map' function
 disable "-d W0142" # used star magic
 
 VAR_NAMES=--variable-rgx='[a-z_][a-z0-9_]*$'
+DUMMY_NAMES='--dummy-variables-rgx=_.*'
 MISC=--max-line-length=82
 
-pylint --rcfile=/dev/null --reports=n $DISABLED "$VAR_NAMES" $MISC $* \
+pylint --rcfile=/dev/null --reports=n $DISABLED "$VAR_NAMES" "$DUMMY_NAMES" $MISC $* \
     "$TEMPLATE" \
     | egrep -v -f $FALSE_POSITIVES

--- a/tests/README
+++ b/tests/README
@@ -1,0 +1,8 @@
+To run tests from the source tree, run this
+(working directory = root of the source tree):
+
+export PYTHONPATH=./plugins
+nosetests tests/
+
+You can run tests under specific Python version using nosetests-2.7
+or nosetests-3.4.

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -170,8 +170,8 @@ class DownloadlCommandTest(unittest.TestCase):
         self.assertFalse(repos['foobar-source'].enabled)
         self.cmd._enable_source_repos()
         self.assertTrue(repos['foo-source'].enabled)
-        self.assertFalse(repos['foo'].enabled)
-        self.assertFalse(repos['bar'].enabled)
+        self.assertTrue(repos['foo'].enabled)
+        self.assertTrue(repos['bar'].enabled)
         self.assertFalse(repos['foobar-source'].enabled)
 
     def test_get_source_packages(self):


### PR DESCRIPTION
This PR will fix the packages query output by per package information.
Currently we get
[parag@f21 dnf]$ sudo dnf repoquery --provides libreoffice-langpack-pt-BR
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.5.2-12.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.5.2-12.fc21
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.2.2-5.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.2.2-5.fc21
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.5.2-11.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.5.2-11.fc21
[parag@f21 dnf]$ 

And with this fix it will be
[parag@f21 dnf]$ sudo dnf repoquery --provides libreoffice-langpack-pt-BR
libreoffice-langpack-pt-BR-1:4.3.5.2-12.fc21.x86_64
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.5.2-12.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.5.2-12.fc21
 
libreoffice-langpack-pt-BR-1:4.3.2.2-5.fc21.x86_64
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.2.2-5.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.2.2-5.fc21
 
libreoffice-langpack-pt-BR-1:4.3.5.2-11.fc21.x86_64
libreoffice-langpack-pt_BR
libreoffice-langpack-pt-BR = 1:4.3.5.2-11.fc21
libreoffice-langpack-pt-BR(x86-64) = 1:4.3.5.2-11.fc21
 
[parag@f21 dnf]$ 
