### PR TITLE
download: Do not disable user-enabled repos

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -162,10 +162,9 @@ class DownloadCommand(dnf.cli.Command):
                 repo_dict[repo.id] = (repo, self.base.repos[source_repo])
             else:
                 repo_dict[repo.id] = (repo, None)
-        # disable the binary & enable the source ones
+        # enable the source repos
         for id_ in repo_dict:
             repo, src_repo = repo_dict[id_]
-            repo.disable()
             if src_repo:
                 logger.info(_('enabled %s repository') % src_repo.id)
                 src_repo.enable()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -170,8 +170,8 @@ class DownloadlCommandTest(unittest.TestCase):
         self.assertFalse(repos['foobar-source'].enabled)
         self.cmd._enable_source_repos()
         self.assertTrue(repos['foo-source'].enabled)
-        self.assertFalse(repos['foo'].enabled)
-        self.assertFalse(repos['bar'].enabled)
+        self.assertTrue(repos['foo'].enabled)
+        self.assertTrue(repos['bar'].enabled)
         self.assertFalse(repos['foobar-source'].enabled)
 
     def test_get_source_packages(self):


### PR DESCRIPTION
It is not possible to disable repos with binary packages because the
same repos can contain source packages. This applies at least to Fedora
COPR and to user-managed repos too.