### PR TITLE
download: fix package download on Python 3

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -91,8 +91,8 @@ class DownloadCommand(dnf.cli.Command):
         else:
             dest = dnf.i18n.ucd(os.getcwd())
 
-        move = functools.partial(self._move_package, dest)
-        map(move, locations)
+        for pkg in locations:
+            self._move_package(dest, pkg)
 
     def _download_rpms(self, pkg_specs):
         """Download packages to dnf cache."""


### PR DESCRIPTION
Python 3 map() uses lazy evaluation so it packages were never copied to
output directory when the plugin was running under Python 3.