### PR TITLE
repoquery: Added --source switch to show source rpm name

### DIFF
--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -78,6 +78,9 @@ The following are mutually exclusive, i.e. at most one can be specified. If no q
 ``-l, --list``
     Show list of files in the package.
 
+``-s, --source``
+    Show package source RPM name.
+
 ``--obsoletes``
     Display capabilities that the package obsoletes. Same as ``--qf "%{obsoletes}``.
 
@@ -102,6 +105,10 @@ Display NEVRAS of all available packages matching ``light*``::
 Display requires of all ligttpd packages::
 
     dnf repoquery --requires lighttpd
+
+Display source rpm of ligttpd package::
+
+    dnf repoquery --source lighttpd
 
 Display package name that owns the given file::
 

--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -47,6 +47,9 @@ Together with ``<pkg-spec>``, control what packages are displayed in the output.
 ``--arch <arch>``
     Limit the resulting set only to packages of arch ``<arch>``.
 
+``-f <file>``, ``--file <file>``
+    Limit the resulting set only to package that owns ``<file>``.
+
 ``--repoid <id>``
     Limit the resulting set only to packages from repo identified by ``<id>``.
 
@@ -99,6 +102,10 @@ Display NEVRAS of all available packages matching ``light*``::
 Display requires of all ligttpd packages::
 
     dnf repoquery --requires lighttpd
+
+Display package name that owns the given file::
+
+    dnf repoquery --file /etc/lighttpd/lighttpd.conf
 
 Display name, architecture and the containing repository of all lighttpd packages::
 

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -63,6 +63,8 @@ def build_format_fn(opts):
         return info_format
     elif opts.queryfilelist:
         return filelist_format
+    elif opts.querysourcerpm:
+        return sourcerpm_format
     else:
         return rpm2py_format(opts.queryformat).format
 
@@ -72,6 +74,9 @@ def info_format(pkg):
 
 def filelist_format(pkg):
     return "\n".join(pkg.files)
+
+def sourcerpm_format(pkg):
+    return pkg.sourcerpm
 
 def parse_arguments(args):
     # Setup ArgumentParser to handle util
@@ -99,6 +104,9 @@ def parse_arguments(args):
     outform.add_argument('-l', "--list", dest='queryfilelist',
                          default=False, action='store_true',
                          help=_('show list of files in the package'))
+    outform.add_argument('-s', "--source", dest='querysourcerpm',
+                         default=False, action='store_true',
+                         help=_('show package source RPM name'))
     outform.add_argument('--qf', "--queryformat", dest='queryformat',
                          default=QFORMAT_DEFAULT,
                          help=_('format for displaying found packages'))

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -46,6 +46,8 @@ EXPECTED_FILELIST_FORMAT = """\
 /var/foobar\
 """
 
+EXPECTED_SOURCERPM_FORMAT = """\
+foo-1.0.1-1.f20.src.rpm"""
 
 class PkgStub(object):
     def __init__(self):
@@ -97,6 +99,11 @@ class FilelistFormatTest(unittest.TestCase):
         self.assertEqual(repoquery.filelist_format(pkg),
                          EXPECTED_FILELIST_FORMAT)
 
+class SourceRPMFormatTest(unittest.TestCase):
+    def test_info(self):
+        pkg = repoquery.PackageWrapper(PkgStub())
+        self.assertEqual(repoquery.sourcerpm_format(pkg),
+                         EXPECTED_SOURCERPM_FORMAT)
 
 class OutputTest(unittest.TestCase):
     def test_output(self):

--- a/tests/test_repoquery.py
+++ b/tests/test_repoquery.py
@@ -81,6 +81,9 @@ class ArgParseTest(unittest.TestCase):
         opts, _ = repoquery.parse_arguments(['--provides'])
         self.assertEqual(opts.queryformat, '%{provides}')
 
+    def test_file(self):
+        opts, _ = repoquery.parse_arguments(['/var/foobar'])
+        self.assertIsNone(opts.file)
 
 class InfoFormatTest(unittest.TestCase):
     def test_info(self):


### PR DESCRIPTION
As requested in PR#77 I have split the commit into 
documentation for file switch
feature for source switch