### PR TITLE
spec: fix Conflicts of the new plugins

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -15,8 +15,10 @@ BuildRequires:  cmake
 BuildRequires:  gettext
 %if 0%{?fedora} >= 23
 Requires:   python3-dnf-plugins-core = %{version}-%{release}
+Conflicts:  python-dnf-plugins-core <= 0.1.6-2
 %else
 Requires:   python-dnf-plugins-core = %{version}-%{release}
+Conflicts:  python3-dnf-plugins-core <= 0.1.6-2
 Provides:   dnf-command(kickstart)
 %endif
 Provides:   dnf-command(builddep)


### PR DESCRIPTION
Commit 5429b16 introduced some file conflicts that need to be explicitly expressed to fix upgrade path. I mean, now it's not possible to install dnf-plugins-core-0.1.6-1 if python3-dnf-plugins-core-0.1.5-1 is installed. The package manager complains about file conflicts.

~~BTW: In the rawhide spec, it must be: ```+Obsoletes:  python-dnf-plugins-core <= 0.1.6-2``` and ```+Obsoletes:  python3-dnf-plugins-core <= 0.1.6-2``` since we have ```dnf-plugins-core-0.1.6-2``` in rawhide already...~~