### PR TITLE
repoquery: add --resolve option (RhBug:1156487)

### DIFF
--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -100,6 +100,9 @@ The following are mutually exclusive, i.e. at most one can be specified. If no q
 ``--requires``
     Display capabilities that the package depends on. Same as ``--qf "%{requires}``.
 
+``--resolve``
+    resolve capabilities to originating package(s).
+
 
 --------
 Examples
@@ -112,6 +115,10 @@ Display NEVRAS of all available packages matching ``light*``::
 Display requires of all ligttpd packages::
 
     dnf repoquery --requires lighttpd
+
+Display packages providing the requires of python packages::
+
+    dnf repoquery --requires python --resolve
 
 Display source rpm of ligttpd package::
 

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -96,6 +96,9 @@ def parse_arguments(args):
     parser.add_argument('--querytags', action='store_true',
                         help=_('show available tags to use with '
                                '--queryformat'))
+    parser.add_argument('--resolve', action='store_true',
+                        help=_('resolve capabilities to originating package(s)')
+                       )
 
     outform = parser.add_mutually_exclusive_group()
     outform.add_argument('-i', "--info", dest='queryinfo',
@@ -195,6 +198,19 @@ class RepoQueryCommand(dnf.cli.Command):
             return query.filter(empty=True)
         return query.filter(requires=reldep)
 
+    @staticmethod
+    def filter_repo_arch(sack, opts, query=None):
+        """Filter query by repoid and arch options"""
+        if query:
+            q = query
+        else:
+            q = sack.query().available()
+        if opts.repoid:
+            q = q.filter(reponame=opts.repoid)
+        if opts.arch:
+            q = q.filter(arch=opts.arch)
+        return q
+
     def configure(self, args):
         demands = self.cli.demands
         demands.sack_activation = True
@@ -228,10 +244,9 @@ class RepoQueryCommand(dnf.cli.Command):
             # do not show packages from @System repo
             q = q.available()
 
-        if opts.repoid:
-            q = q.filter(reponame=opts.repoid)
-        if opts.arch:
-            q = q.filter(arch=opts.arch)
+        # filter repo and arch
+        q = self.filter_repo_arch(self.base.sack, opts, q)
+
         if opts.file:
             q = q.filter(file=opts.file)
         if opts.whatprovides:
@@ -239,7 +254,10 @@ class RepoQueryCommand(dnf.cli.Command):
         if opts.whatrequires:
             q = self.by_requires(self.base.sack, opts.whatrequires, q)
         fmt_fn = build_format_fn(opts)
-        self.show_packages(q, fmt_fn)
+        if opts.resolve:
+            self.show_resolved_packages(q, fmt_fn, opts)
+        else:
+            self.show_packages(q, fmt_fn)
 
     @staticmethod
     def show_packages(query, fmt_fn):
@@ -252,6 +270,27 @@ class RepoQueryCommand(dnf.cli.Command):
                 # catch that the user has specified attributes
                 # there don't exist on the dnf Package object.
                 raise dnf.exceptions.Error(str(e))
+
+    def show_resolved_packages(self, query, fmt_fn, opts):
+        """Print packages providing capabilities from a query"""
+        capabilities = list()
+        for po in query.run():
+            try:
+                pkg = PackageWrapper(po)
+                capabilities.extend(fmt_fn(pkg).split('\n'))
+            except AttributeError as e:
+                # catch that the user has specified attributes
+                # there don't exist on the dnf Package object.
+                raise dnf.exceptions.Error(str(e))
+
+        # find the providing packages and show them
+        query = self.filter_repo_arch(self.base.sack, opts)
+        providers = self.by_provides(self.base.sack, list(capabilities),
+                                     query)
+        fmt_fn = rpm2py_format(QFORMAT_DEFAULT).format
+        for po in providers.latest().run():
+            pkg = PackageWrapper(po)
+            print(fmt_fn(pkg))
 
 
 class PackageWrapper(object):


### PR DESCRIPTION
Add a new --resolve option there works as in repoquery in yum-utils.

**show the requirement for python**
$ sudo dnf repoquery --requires python -d0
rtld(GNU_HASH)
libm.so.6
libpthread.so.0
libdl.so.2
libutil.so.1
libpython2.7.so.1.0
libc.so.6(GLIBC_2.0)
python-libs(x86-32) = 2.7.8-7.fc21
rtld(GNU_HASH)
libm.so.6()(64bit)
libpthread.so.0()(64bit)
libdl.so.2()(64bit)
libc.so.6(GLIBC_2.2.5)(64bit)
libutil.so.1()(64bit)
libpython2.7.so.1.0()(64bit)
python-libs(x86-64) = 2.7.8-7.fc21

** Show the packages providing the requirements for python**
$ sudo dnf repoquery --requires python --resolve -d0
python-libs-0:2.7.8-7.fc21.i686
python-libs-0:2.7.8-7.fc21.x86_64
glibc-0:2.20-8.fc21.x86_64
glibc-0:2.20-8.fc21.i686


