### PR TITLE
debuginfo-install: don't consider src packages as candidates for install...

### DIFF
--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -65,7 +65,7 @@ class DebuginfoInstallCommand(dnf.cli.Command):
 
         for pkgspec in args:
             for pkg in dnf.subject.Subject(pkgspec).get_best_query(
-                    self.cli.base.sack):
+                    self.cli.base.sack).filter(arch__neq='src'):
                 self._di_install(pkg)
 
     @staticmethod


### PR DESCRIPTION
...ation (RhBug:1215154)

Sometimes there's src.rpm packages in the repositories (e.g. COPR).
Debuginfo-install would blow up if they matched the query:

  [root@belphegor lkundrak]# dnf debuginfo-install network-manager-applet
  Fedora 22 - x86_64 - Updates - Debug                     3.3 kB/s | 257  B     00:00
  Fedora 22 - x86_64 - Debug                                19 MB/s |  11 MB     00:00
  Fedora 22 - x86_64 - Test Updates Debug                   19 MB/s | 4.1 MB     00:00
  RPM Fusion for Fedora 22 - Free - Updates Debug          6.7 kB/s | 411  B     00:00
  Traceback (most recent call last):
    File "/usr/bin/dnf", line 36, in <module>
      main.user_main(sys.argv[1:], exit_code=True)
    File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 185, in user_main
      errcode = main(args)
    File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 84, in main
      return _main(base, args)
    File "/usr/lib/python2.7/site-packages/dnf/cli/main.py", line 134, in _main
      cli.run()
    File "/usr/lib/python2.7/site-packages/dnf/cli/cli.py", line 1071, in run
      return self.command.run(self.base.extcmds)
    File "/usr/lib/python2.7/site-packages/dnf-plugins/debuginfo-install.py", line 70, in run
      self._di_install(pkg)
    File "/usr/lib/python2.7/site-packages/dnf-plugins/debuginfo-install.py", line 102, in _di_install
      srcname = self._pkgname_src(package)
    File "/usr/lib/python2.7/site-packages/dnf-plugins/debuginfo-install.py", line 75, in _pkgname_src
      name = package.sourcerpm.replace("-{}.src.rpm".format(package.evr), "")
  AttributeError: 'NoneType' object has no attribute 'replace'
  [root@belphegor lkundrak]#