### PR TITLE
spec: allow DNF 1.x.x

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,5 +1,5 @@
 %{?!dnf_lowest_compatible: %global dnf_lowest_compatible 0.6.5}
-%{?!dnf_not_compatible: %global dnf_not_compatible 1.0}
+%{?!dnf_not_compatible: %global dnf_not_compatible 2.0}
 
 Name:       dnf-plugins-core
 Version:    0.1.6


### PR DESCRIPTION
The major version bump did not introduce backwards incompatible changes.

It's needed to fix our CI job!

I did just some sanity tests since I don't expect that something should break.