### PR TITLE
spec: fix an upgrade path from dnf-plugins-core <= 0.1.5

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -55,7 +55,7 @@ Requires:   python-kickstart
 Requires:   pykickstart
 %endif
 Requires:   python-requests
-Obsoletes:  dnf-plugins-core <= 0.1.5
+Conflicts:  dnf-plugins-core <= 0.1.5
 %description -n python-dnf-plugins-core
 Core Plugins for DNF, Python 2 interface. This package enhance DNF with builddep, copr,
 debuginfo-install, download, kickstart, needs-restarting, repoquery and
@@ -73,7 +73,7 @@ BuildRequires:  python3-sphinx
 Requires:   python3-requests
 Requires:   python3-dnf >= %{dnf_lowest_compatible}
 Requires:   python3-dnf < %{dnf_not_compatible}
-Obsoletes:  dnf-plugins-core <= 0.1.5
+Conflicts:  dnf-plugins-core <= 0.1.5
 %description -n python3-dnf-plugins-core
 Core Plugins for DNF, Python 3 interface. This package enhance DNF with builddep, copr,
 config-manager, debuginfo-install, download, needs-restarting, repoquery and


### PR DESCRIPTION
Currently, it removes dnf-plugins-core when fresh installations of F22 are upgraded.
```
# dnf upgrade
...
Installing:
 python-dnf-plugins-core  noarch 0.1.7-1.fc22             updates-testing  77 k
     replacing  dnf-plugins-core.noarch 0.1.5-1.fc22
...
 python3-dnf-plugins-core noarch 0.1.7-1.fc22             updates-testing  53 k
     replacing  dnf-plugins-core.noarch 0.1.5-1.fc22
...

```

It would be nice if it could get into F22+ as soon as possible so that as few users as possible end up with no dnf-plugins-core package installed.