### PR TITLE
[copr] disable subcommand set `enabled=0`, not rm .repo file

### DIFF
--- a/doc/copr.rst
+++ b/doc/copr.rst
@@ -28,7 +28,7 @@ Work with Copr & Playground repositories on the local system.
 Synopsis
 --------
 
-``dnf copr [enable|disable|list|search] <parameters>``
+``dnf copr [enable|disable|remove|list|search] <parameters>``
 
 ``dnf playground [enable|disable|upgrade]``
 
@@ -41,6 +41,9 @@ Arguments (copr)
 
 ``disable name/project``
     Disable the ``name/project`` Copr repository.
+
+``remove name/project``
+    Remove the ``name/project`` Copr repository.
 
 ``list name``
     List available Copr repositories for a given ``name``.

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -19,7 +19,7 @@
 
 from __future__ import print_function
 from dnf.pycomp import PY3
-from subprocess import Popen, call
+from subprocess import call
 from dnfpluginscore import _, logger
 from dnf.i18n import ucd
 import dnfpluginscore.lib

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -105,6 +105,7 @@ class CoprCommand(dnf.cli.Command):
                 _('Error: ') +
                 _('use format `copr_username/copr_projectname` '
                   'to reference copr project'))
+            raise dnf.cli.CliError(_('bad copr project format'))
 
         repo_filename = "/etc/yum.repos.d/_copr_{}-{}.repo" \
                         .format(copr_username, copr_projectname)


### PR DESCRIPTION
Subcommand `disable` now only set `enabled=0`, repo file could be deleted by new subcommand `remove`.
This feature will be useful with https://fedoraproject.org/wiki/Changes/DisabledRepoSupport 