### PR TITLE
Resolve local RPMs when downloading

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -33,6 +33,8 @@ Arguments
 
 ``<pkg-spec>``
     Package specification for the package to download.
+    Local RPMs can be specified as well. This is useful with the ``--source``
+    option or if you want to download the same RPM again.
 
 -------
 Options

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -171,7 +171,7 @@ class DownloadCommand(dnf.cli.Command):
         """Return a query to match a pkg_spec."""
         if os.path.exists(pkg_spec):
             pkg = self.base.add_remote_rpm(pkg_spec)
-            pkg_spec = pkg.name
+            pkg_spec = "{0.name}-{0.epoch}:{0.version}-{0.release}.{0.arch}".format(pkg)
 
         subj = dnf.subject.Subject(pkg_spec)
         q = subj.get_best_query(self.base.sack)

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -169,6 +169,10 @@ class DownloadCommand(dnf.cli.Command):
 
     def _get_query(self, pkg_spec):
         """Return a query to match a pkg_spec."""
+        if os.path.exists(pkg_spec):
+            pkg = self.base.add_remote_rpm(pkg_spec)
+            pkg_spec = pkg.name
+
         subj = dnf.subject.Subject(pkg_spec)
         q = subj.get_best_query(self.base.sack)
         q = q.available()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -277,10 +277,19 @@ class DownloadCommandTest(unittest.TestCase):
         self.assertEqual(len(pkgs), 2)
         self.assertEqual(pkgs[0].name, 'bar')
         self.assertEqual(pkgs[1].name, 'foo')
+
+        strict_orig = self.cmd.base.conf.strict
+        self.cmd.base.conf.strict = True
+        with self.assertRaises(dnf.exceptions.Error):
+            pkgs = self.cmd._get_packages(['notfound'])
+            pkgs = self.cmd._get_packages(['notfound', 'bar'])
+        self.cmd.base.conf.strict = False
         pkgs = self.cmd._get_packages(['notfound'])
         self.assertEqual(len(pkgs), 0)
         pkgs = self.cmd._get_packages(['notfound', 'bar'])
         self.assertEqual(len(pkgs), 1)
+        self.cmd.base.conf.strict = strict_orig
+
         self.assertEqual(pkgs[0].name, 'bar')
         pkgs = self.cmd._get_packages(['foo-2.0-1.src.rpm'], source=True)
         self.assertEqual(len(pkgs), 1)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -25,6 +25,9 @@ import dnf.subject
 import dnfpluginscore
 import download
 import unittest
+import hawkey
+import tempfile
+import os
 
 
 class PkgStub:
@@ -247,6 +250,18 @@ class DownloadCommandTest(unittest.TestCase):
         found = self.cmd._get_query('bar')
         self.assertEqual(len(found), 1)
         self.assertEqual(found[0].name, 'bar')
+
+    def test_get_query_with_local_rpm(self):
+        try:
+            (fs, rpm_path) = tempfile.mkstemp('foobar-99.99-1.x86_64.rpm')
+            # b/c self.cmd.cli.base is a mock object add_remote_rpm
+            # will not update the available packages while testing.
+            # it is expected to hit an exception
+            with self.assertRaises(dnf.exceptions.PackageNotFoundError):
+                self.cmd._get_query(rpm_path)
+            self.cmd.cli.base.add_remote_rpm.assert_called_with(rpm_path)
+        finally:
+            os.remove(rpm_path)
 
     def test_get_query_source(self):
         pkgs = self.cmd._get_query_source('foo-2.0-1.src.rpm')


### PR DESCRIPTION
This makes it easier to specify --source (and a --debuginfo which I'm going to add) and pass a local rpm files as argument. 

My use case is that I'm iterating over the local RPMs from a bash script and want to download their source/debuginfo counterparts w/o necessarily parsing the file name.