### PR TITLE
Fix for Bug 1265622 - 'dnf builddep' is not always as 'clever' as yum-builddep or dnf download --source

### DIFF
--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -208,8 +208,11 @@ class BuildDepCommand(dnf.cli.Command):
             raise dnf.exceptions.Error(err)
 
     def _remote_deps(self, package):
-        pkgs = self.base.sack.query().available().filter(name=package,
-                                                         arch="src").run()
+        sourcenames = list({dnfpluginscore.lib.package_source_name(pkg)
+                           for pkg in dnf.subject.Subject(
+                               package).get_best_query(self.base.sack)})
+        pkgs = self.base.sack.query().available().filter(
+                name=(sourcenames + [package]), arch="src").latest().run()
         if not pkgs:
             raise dnf.exceptions.Error(_('no package matched: %s') % package)
         self.base.download_packages(pkgs)

--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -69,21 +69,6 @@ class DebuginfoInstallCommand(dnf.cli.Command):
                     self.cli.base.sack).filter(arch__neq='src'):
                 self._di_install(pkg)
 
-    @staticmethod
-    def _pkg_dbgname(package):
-        """get package name with debuginfo suffix, e.g. kernel-PAE-debuginfo"""
-        return "{}-debuginfo".format(package.name)
-
-    @staticmethod
-    def _pkg_dbgsrcname(package):
-        """get package name with debuginfo suffix, e.g. krb5-debuginfo"""
-        # strip src suffix
-        srcname = package.sourcerpm.rstrip(".src.rpm")
-        # source package filenames may not contain epoch, handle both cases
-        srcname = srcname.rstrip("-{}".format(package.evr))
-        srcname = srcname.rstrip("-{0.version}-{0.release}".format(package))
-        return "{}-debuginfo".format(srcname)
-
     def _dbg_available(self, dbgname, package, match_evra):
         if match_evra:
             return self.packages_available.filter(
@@ -98,7 +83,8 @@ class DebuginfoInstallCommand(dnf.cli.Command):
                 arch=str(package.arch))
 
     def _di_install(self, package):
-        for dbgname in [self._pkg_dbgname(package), self._pkg_dbgsrcname(package)]:
+        for dbgname in [dnfpluginscore.lib.package_debug_name(package),
+                        dnfpluginscore.lib.package_source_debug_name(package)]:
             if dbgname in self.dbgdone:
                 break
             if self._dbg_available(dbgname, package, True):

--- a/plugins/dnfpluginscore/lib.py
+++ b/plugins/dnfpluginscore/lib.py
@@ -151,3 +151,33 @@ def enable_debug_repos(repos):
         return ("{}-debug-rpms".format(name[:-5]) if name.endswith("-rpms")
                 else "{}-debuginfo".format(name))
     _enable_sub_repos(repos, debug_name)
+
+def package_debug_name(package):
+    """
+    # :api
+    returns name of debuginfo package for given package
+    e.g. kernel-PAE -> kernel-PAE-debuginfo
+    """
+    return "{}-debuginfo".format(package.name)
+
+def package_source_name(package):
+    """"
+    # :api
+    returns name of source package for given pkgname
+    e.g. krb5-libs -> krb5
+    """
+    # strip suffix first
+    srcname = package.sourcerpm.rstrip(".src.rpm")
+    # source package filenames may not contain epoch, handle both cases
+    srcname = srcname.rstrip("-{}".format(package.evr))
+    srcname = srcname.rstrip("-{0.version}-{0.release}".format(package))
+    return srcname
+
+def package_source_debug_name(package):
+    """
+    # :api
+    returns name of debuginfo package for source package of given package
+    e.g. krb5-libs -> krb5-debuginfo
+    """
+    srcname = package_source_name(package)
+    return "{}-debuginfo".format(srcname)


### PR DESCRIPTION
This PR depends on #116 and should be merged after it.