### PR TITLE
Exit with non-zero status if strict and package not found

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -31,6 +31,7 @@ import hawkey
 import itertools
 import os
 import shutil
+import sys
 
 
 class Download(dnf.Plugin):
@@ -131,6 +132,10 @@ class DownloadCommand(dnf.cli.Command):
                 queries.append(func(pkg_spec))
             except dnf.exceptions.PackageNotFoundError as e:
                 logger.error(dnf.i18n.ucd(e))
+                if self.base.conf.strict:
+                    logger.error(_("Exiting due to strict setting.")
+                    sys.exit(1)
+
         pkgs = list(itertools.chain(*queries))
         return pkgs
 

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -31,7 +31,6 @@ import hawkey
 import itertools
 import os
 import shutil
-import sys
 
 
 class Download(dnf.Plugin):
@@ -134,7 +133,7 @@ class DownloadCommand(dnf.cli.Command):
                 logger.error(dnf.i18n.ucd(e))
                 if self.base.conf.strict:
                     logger.error(_("Exiting due to strict setting."))
-                    sys.exit(1)
+                    raise dnf.exceptions.Error(e)
 
         pkgs = list(itertools.chain(*queries))
         return pkgs

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -133,7 +133,7 @@ class DownloadCommand(dnf.cli.Command):
             except dnf.exceptions.PackageNotFoundError as e:
                 logger.error(dnf.i18n.ucd(e))
                 if self.base.conf.strict:
-                    logger.error(_("Exiting due to strict setting.")
+                    logger.error(_("Exiting due to strict setting."))
                     sys.exit(1)
 
         pkgs = list(itertools.chain(*queries))


### PR DESCRIPTION
If all packages are found, download packages and exit with status code
0.

If the `strict` base conf is True, and one or more packages are not
found, don't download any package and exit with status code 1.

If `strict` is False and one or more packages are not found, download
the found packages and exit with status code 0.