### PR TITLE
repoquery: Fix UnicodeEncodeError with --info (RhBug:1264125)

### DIFF
--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -445,7 +445,7 @@ class PackageWrapper(object):
         atr = getattr(self._pkg, attr)
         if isinstance(atr, list):
             return '\n'.join(sorted([str(reldep) for reldep in atr]))
-        return str(atr)
+        return dnf.i18n.ucd(atr)
 
     @staticmethod
     def _get_timestamp(timestamp):


### PR DESCRIPTION
Fix 'dnf repoquery --info' when character like u'\u2019' appears.