### PR TITLE
Fix cmdline conversion to unicode (RhBug:1265210)

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -97,7 +97,7 @@ def parse_args(args):
 def print_cmd(pid):
     cmdline = '/proc/%d/cmdline' % pid
     with open(cmdline) as cmdline_file:
-        command = cmdline_file.read()
+        command = dnf.i18n.ucd(cmdline_file.read())
     command = ' '.join(command.split('\000'))
     print('%d : %s' % (pid, command))
 


### PR DESCRIPTION
Previously, in Python 2, an implicit conversion to unicode was attempted
when the cmdline string was passed to str.split().  However, that failed
if some non-ascii bytes were present because the default ascii codec was
used.

This commit makes sure the string is converted properly.