### PR TITLE
builddep: do not download source package

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ DNF-PLUGINS-CORE CONTRIBUTORS
     Wieland Hoffmann
     Rickard Dybeck <r.dybeck@gmail.com>
     Michal Domonkos <mdomonko@redhat.com>
+    Jeff Smith <whydoubt@gmail.com>

--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -216,6 +216,11 @@ class BuildDepCommand(dnf.cli.Command):
                 name=(sourcenames + [package]), arch="src").latest().run()
         if not pkgs:
             raise dnf.exceptions.Error(_('no package matched: %s') % package)
-        self.base.download_packages(pkgs)
+        done = True
         for pkg in pkgs:
-            self._src_deps(pkg.localPkg())
+            for req in pkg.requires:
+                done &= self._install(str(req))
+
+        if not done:
+            err = _("Not all dependencies satisfied")
+            raise dnf.exceptions.Error(err)


### PR DESCRIPTION
The build-dependency information for a source package is contained in
the repodata.  Because of this, it is not necessary to download the 
source package to evaluate the build dependencies.