### PR TITLE
latest-limit option moved to base set of options making it compatible with --queryformat and other output formatters (RhBug: 1292475)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ DNF-PLUGINS-CORE CONTRIBUTORS
     Wieland Hoffmann
     Rickard Dybeck <r.dybeck@gmail.com>
     Michal Domonkos <mdomonko@redhat.com>
+    Michal Novotny <clime@redhat.com>

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -117,6 +117,9 @@ def parse_arguments(args):
                         help=_('show recursive tree for package(s)'))
     parser.add_argument('--srpm', action='store_true',
                         help=_('operate on corresponding source RPM'))
+    parser.add_argument("--latest-limit", dest='latest_limit', type=int,
+                         help=_('show N latest packages for a given name.arch'
+                                ' (or latest but N if N is negative)'))
 
     outform = parser.add_mutually_exclusive_group()
     outform.add_argument('-i', "--info", dest='queryinfo',
@@ -131,9 +134,6 @@ def parse_arguments(args):
     outform.add_argument('--qf', "--queryformat", dest='queryformat',
                          default=QFORMAT_DEFAULT,
                          help=_('format for displaying found packages'))
-    outform.add_argument("--latest-limit", dest='latest_limit', type=int,
-                         help=_('show N latest packages for a given name.arch'
-                                ' (or latest but N if N is negative)'))
 
     pkgfilter = parser.add_mutually_exclusive_group()
     pkgfilter.add_argument("--duplicated", dest='pkgfilter',


### PR DESCRIPTION
latest-limit option moved to base set of options making it compatible with --queryformat and other output formatters (see https://bugzilla.redhat.com/show_bug.cgi?id=1292475)