### PR TITLE
copr: Add logic to detect correct reposdir location and override detected copr chroot support

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -162,7 +162,7 @@ class ConfigManagerCommand(dnf.cli.Command):
         """ process --add-repo option """
 
         # Get the reposdir location
-        myrepodir = dnfpluginscore.lib.get_reposdir()
+        myrepodir = dnfpluginscore.lib.get_reposdir(self)
 
         for url in self.opts.add_repo:
             if dnf.pycomp.urlparse.urlparse(url).scheme == '':

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -161,16 +161,8 @@ class ConfigManagerCommand(dnf.cli.Command):
     def add_repo(self):
         """ process --add-repo option """
 
-        # put repo file into first reposdir which exists or create it
-        myrepodir = None
-        for rdir in self.base.conf.reposdir:
-            if os.path.exists(rdir):
-                myrepodir = rdir
-                break
-
-        if not myrepodir:
-            myrepodir = self.base.conf.reposdir[0]
-            dnf.util.ensure_dir(myrepodir)
+        # Get the reposdir location
+        myrepodir = dnfpluginscore.lib.get_reposdir()
 
         for url in self.opts.add_repo:
             if dnf.pycomp.urlparse.urlparse(url).scheme == '':

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -94,18 +94,6 @@ class CoprCommand(dnf.cli.Command):
   copr search tests
     """)
 
-    def _get_reposdir(self):
-        myrepodir = None
-        # put repo file into first reposdir which exists or create it
-        for rdir in self.base.conf.reposdir:
-            if os.path.exists(rdir):
-                myrepodir = rdir
-
-            if not myrepodir:
-                myrepodir = self.base.conf.reposdir[0]
-                dnf.util.ensure_dir(myrepodir)
-        return myrepodir
-
     def configure(self, args):
         raw_config = ConfigParser()
         filepath = os.path.join(os.path.expanduser("~"), ".config", "copr")
@@ -160,7 +148,7 @@ class CoprCommand(dnf.cli.Command):
             raise dnf.cli.CliError(_('bad copr project format'))
 
         repo_filename = "{}/_copr_{}-{}.repo" \
-                        .format(self._get_reposdir(), copr_username, copr_projectname)
+                        .format(dnfpluginscore.lib.get_reposdir(self), copr_username, copr_projectname)
         if subcommand == "enable":
             self._need_root()
             self._ask_user("""
@@ -397,7 +385,7 @@ Do you want to continue? [y/N]: """)
             project_name = "{0}/{1}".format(repo["username"],
                                             repo["coprname"])
             repo_filename = "{}/_playground_{}.repo" \
-                    .format(self._get_reposdir(), project_name.replace("/", "-"))
+                    .format(dnfpluginscore.lib.get_reposdir(self), project_name.replace("/", "-"))
             try:
                 if chroot not in repo["chroots"]:
                     continue
@@ -415,7 +403,7 @@ Do you want to continue? [y/N]: """)
 
     def _cmd_disable(self):
         self._need_root()
-        for repo_filename in glob.glob("{}/_playground_*.repo".format(self._get_reposdir())):
+        for repo_filename in glob.glob("{}/_playground_*.repo".format(dnfpluginscore.lib.get_reposdir(self))):
             self._remove_repo(repo_filename)
 
     def run(self, extcmds):

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -31,6 +31,7 @@ import os
 import platform
 import shutil
 import stat
+import iniparse
 
 PLUGIN_CONF = 'copr'
 
@@ -94,7 +95,12 @@ class CoprCommand(dnf.cli.Command):
             if self.copr_url != "https://copr.fedoraproject.org":
                 print(_("Warning: we are using non-standard Copr URL '{}'.").format(self.copr_url))
 
+
         # Useful for forcing a distribution
+        raw_copr_plugin_config = iniparse.compat.ConfigParser()
+        config_files = ['{}/{}.conf'.format(self.base.conf, PLUGIN_CONF) for path in self.base.conf.pluginconfpath]
+        cp.read(config_files)
+
         cp = self.read_config(self.base.conf, PLUGIN_CONF)
         distribution = (cp.has_section('main')
                         and cp.has_option('main', 'distribution')

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -45,6 +45,18 @@ if PY3:
 else:
     from ConfigParser import ConfigParser
 
+def get_reposdir():
+    myrepodir = None
+    # put repo file into first reposdir which exists or create it
+    for rdir in self.base.conf.reposdir:
+        if os.path.exists(rdir):
+            myrepodir = rdir
+
+        if not myrepodir:
+            myrepodir = self.base.conf.reposdir[0]
+            dnf.util.ensure_dir(myrepodir)
+    return myrepodir
+
 class Copr(dnf.Plugin):
     """DNF plugin supplying the 'copr' command."""
 
@@ -132,8 +144,8 @@ class CoprCommand(dnf.cli.Command):
                   'to reference copr project'))
             raise dnf.cli.CliError(_('bad copr project format'))
 
-        repo_filename = "/etc/yum.repos.d/_copr_{}-{}.repo" \
-                        .format(copr_username, copr_projectname)
+        repo_filename = "{}/_copr_{}-{}.repo" \
+                        .format(get_reposdir(), copr_username, copr_projectname)
         if subcommand == "enable":
             self._need_root()
             self._ask_user("""
@@ -367,8 +379,8 @@ Do you want to continue? [y/N]: """)
         for repo in output["repos"]:
             project_name = "{0}/{1}".format(repo["username"],
                                             repo["coprname"])
-            repo_filename = "/etc/yum.repos.d/_playground_{}.repo" \
-                    .format(project_name.replace("/", "-"))
+            repo_filename = "{}/_playground_{}.repo" \
+                    .format(get_reposdir(), project_name.replace("/", "-"))
             try:
                 if chroot not in repo["chroots"]:
                     continue
@@ -386,7 +398,7 @@ Do you want to continue? [y/N]: """)
 
     def _cmd_disable(self):
         self._need_root()
-        for repo_filename in glob.glob('/etc/yum.repos.d/_playground_*.repo'):
+        for repo_filename in glob.glob("{}/_playground_*.repo".format(get_reposdir())):
             self._remove_repo(repo_filename)
 
     def run(self, extcmds):

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -34,8 +34,6 @@ import stat
 
 PLUGIN_CONF = 'copr'
 
-CHROOT_CONFIG = None
-
 YES = set([_('yes'), _('y')])
 NO = set([_('no'), _('n'), ''])
 
@@ -60,20 +58,11 @@ class Copr(dnf.Plugin):
         if cli is not None:
             cli.register_command(CoprCommand)
 
-    # Useful for forcing a distribution
-    def config(self):
-        cp = self.read_config(self.base.conf, PLUGIN_CONF)
-        distribution = (cp.has_section('main')
-                        and cp.has_option('main', 'distribution')
-                        and cp.get('main', 'distribution'))
-        releasever = (cp.has_section('main')
-                      and cp.has_option('main', 'releasever')
-                      and cp.get('main', 'releasever'))
-        CHROOT_CONFIG = [distribution, releasever]
-
 
 class CoprCommand(dnf.cli.Command):
     """ Copr plugin for DNF """
+
+    chroot_config = None
 
     copr_url = "https://copr.fedoraproject.org"
     aliases = ("copr",)
@@ -104,6 +93,17 @@ class CoprCommand(dnf.cli.Command):
                 self.copr_url = raw_config.get("copr-cli", "copr_url", None)
             if self.copr_url != "https://copr.fedoraproject.org":
                 print(_("Warning: we are using non-standard Copr URL '{}'.").format(self.copr_url))
+
+        # Useful for forcing a distribution
+        cp = self.read_config(self.base.conf, PLUGIN_CONF)
+        distribution = (cp.has_section('main')
+                        and cp.has_option('main', 'distribution')
+                        and cp.get('main', 'distribution'))
+        releasever = (cp.has_section('main')
+                      and cp.has_option('main', 'releasever')
+                      and cp.get('main', 'releasever'))
+        self.chroot_config = [distribution, releasever]
+
 
     def run(self, extcmds):
         try:
@@ -257,7 +257,7 @@ Do you want to continue? [y/N]: """)
     def _guess_chroot(cls):
         """ Guess which chroot is equivalent to this machine """
         # FIXME Copr should generate non-specific arch repo
-        dist = CHROOT_CONFIG
+        dist = self.chroot_config
         if (dist[0] is False) or (dist[1] is False) or dist is None:
             dist = platform.linux_distribution()
         if "Fedora" in dist:

--- a/plugins/dnfpluginscore/lib.py
+++ b/plugins/dnfpluginscore/lib.py
@@ -23,7 +23,7 @@ import dnf
 import iniparse
 import librepo
 import tempfile
-
+import os
 
 def get_reposdir(plugin):
     """

--- a/plugins/dnfpluginscore/lib.py
+++ b/plugins/dnfpluginscore/lib.py
@@ -25,6 +25,22 @@ import librepo
 import tempfile
 
 
+def get_reposdir(plugin):
+    """
+    # :api
+    Returns the value of reposdir
+    """
+    myrepodir = None
+    # put repo file into first reposdir which exists or create it
+    for rdir in plugin.base.conf.reposdir:
+        if os.path.exists(rdir):
+            myrepodir = rdir
+
+    if not myrepodir:
+        myrepodir = plugin.base.conf.reposdir[0]
+        dnf.util.ensure_dir(myrepodir)
+    return myrepodir
+
 def current_value(plugin, repo, option):
     """
     # :api


### PR DESCRIPTION
The `copr` plugin currently assumes that repos are installed to `/etc/yum.repos.d`. This is a problem as DNF itself can have repositories in `/etc/yum.repos.d`, `/etc/yum/repos.d`, or `/etc/distro.repos.d` by default.

We also expect that Fedora 25 will switch to using `/etc/distro.repos.d`, and Mageia will be using this path in Mageia 6. Even if this wasn't the case, it's a good idea to detect where the reposdir actually is and use that location.

Additionally, derivative distributions (such as Korora) need a way to override the detected chroots, so that they can use the parent distribution's chroots properly.