### PR TITLE
copr: fix traceback when trying to enable non-existing project (RhBug: 304615)

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -269,13 +269,13 @@ Do you want to continue? [y/N]: """)
                 if PY3:
                     import urllib.request
                     try:
-                        res = urllib.request.urlopen(self.copr_url + "/coprs/" + project_name, 'w+')
+                        res = urllib.request.urlopen(self.copr_url + "/coprs/" + project_name)
                         status_code = res.getcode()
                     except urllib.error.HTTPError as e:
                         status_code = e.getcode()
                 else:
                     import urllib
-                    res = urllib.urlopen(self.copr_url + "/coprs/" + project_name, 'w+')
+                    res = urllib.urlopen(self.copr_url + "/coprs/" + project_name)
                     status_code = res.getcode()
                 if str(status_code) != '404':
                     raise dnf.exceptions.Error(_("This repository does not have"\


### PR DESCRIPTION
Please see <https://bugzilla.redhat.com/show_bug.cgi?id=1304615>