### PR TITLE
Support reposdir detection and chroot override in copr plugin

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -161,16 +161,8 @@ class ConfigManagerCommand(dnf.cli.Command):
     def add_repo(self):
         """ process --add-repo option """
 
-        # put repo file into first reposdir which exists or create it
-        myrepodir = None
-        for rdir in self.base.conf.reposdir:
-            if os.path.exists(rdir):
-                myrepodir = rdir
-                break
-
-        if not myrepodir:
-            myrepodir = self.base.conf.reposdir[0]
-            dnf.util.ensure_dir(myrepodir)
+        # Get the reposdir location
+        myrepodir = dnfpluginscore.lib.get_reposdir(self)
 
         for url in self.opts.add_repo:
             if dnf.pycomp.urlparse.urlparse(url).scheme == '':

--- a/plugins/dnfpluginscore/lib.py
+++ b/plugins/dnfpluginscore/lib.py
@@ -23,7 +23,23 @@ import dnf
 import iniparse
 import librepo
 import tempfile
+import os
 
+def get_reposdir(plugin):
+    """
+    # :api
+    Returns the value of reposdir
+    """
+    myrepodir = None
+    # put repo file into first reposdir which exists or create it
+    for rdir in plugin.base.conf.reposdir:
+        if os.path.exists(rdir):
+            myrepodir = rdir
+
+    if not myrepodir:
+        myrepodir = plugin.base.conf.reposdir[0]
+        dnf.util.ensure_dir(myrepodir)
+    return myrepodir
 
 def current_value(plugin, repo, option):
     """


### PR DESCRIPTION
The `copr` plugin currently assumes that repos are installed to `/etc/yum.repos.d`. This is a problem as DNF itself can have repositories in `/etc/yum.repos.d`, `/etc/yum/repos.d`, or `/etc/distro.repos.d` by default.

We also expect that Fedora 25 will switch to using `/etc/distro.repos.d`, and Mageia will be using this path in Mageia 6. Even if this wasn't the case, it's a good idea to detect where the reposdir actually is and use that location.

Additionally, derivative distributions (such as Korora) need a way to override the detected chroots, so that they can use the parent distribution's chroots properly.

This PR also adds a new API for getting `reposdir` in the `dnfpluginscore.lib`, and changes config_manager to use it.