### PR TITLE
Incorrect option --repo instead of --repoid in manual

### DIFF
--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -26,6 +26,7 @@ Synopsis
 --------
 
 ``dnf repoquery [<select-options>] [<query-options>] [<pkg-spec>]``
+
 ``dnf repoquery --querytags``
 
 -----------
@@ -76,7 +77,7 @@ Together with ``<pkg-spec>``, control what packages are displayed in the output.
 ``--recent``
     Limit the resulting set to packages that were recently edited.
 
-``--repo <repoid>``
+``--repoid <repoid>``
     Limit the resulting set only to packages from repo identified by ``<repoid>``.
     Can be used multiple times with accumulative effect.
 


### PR DESCRIPTION
Also added a line break to the synopsis to fix ambiguity