### PR TITLE
DNF2: make plugin command registration easier

### DIFF
--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -32,14 +32,6 @@ import functools
 import os
 import rpm
 
-class BuildDep(dnf.Plugin):
-
-    name = 'builddep'
-
-    def __init__(self, base, cli):
-        super(BuildDep, self).__init__(base, cli)
-        if cli:
-            cli.register_command(BuildDepCommand)
 
 
 class sink_rpm_logging(object):
@@ -61,6 +53,7 @@ class sink_rpm_logging(object):
         self.sink.close()
 
 
+@dnf.plugin.register_command
 class BuildDepCommand(dnf.cli.Command):
 
     aliases = ('builddep',)

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -30,18 +30,7 @@ import re
 import shutil
 
 
-class ConfigManager(dnf.Plugin):
-
-    name = 'config-manager'
-
-    def __init__(self, base, cli):
-        super(ConfigManager, self).__init__(base, cli)
-        self.base = base
-        self.cli = cli
-        if self.cli is not None:
-            self.cli.register_command(ConfigManagerCommand)
-
-
+@dnf.plugin.register_command
 class ConfigManagerCommand(dnf.cli.Command):
 
     aliases = ['config-manager']

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -48,18 +48,7 @@ if PY3:
 else:
     from ConfigParser import ConfigParser
 
-class Copr(dnf.Plugin):
-    """DNF plugin supplying the 'copr' command."""
-
-    name = 'copr'
-
-    def __init__(self, base, cli):
-        """Initialize the plugin instance."""
-        super(Copr, self).__init__(base, cli)
-        if cli is not None:
-            cli.register_command(CoprCommand)
-
-
+@dnf.plugin.register_command
 class CoprCommand(dnf.cli.Command):
     """ Copr plugin for DNF """
 
@@ -368,18 +357,7 @@ Do you want to continue? [y/N]: """)
             return copr_username
 
 
-class Playground(dnf.Plugin):
-    """DNF plugin supplying the 'playground' command."""
-
-    name = 'playground'
-
-    def __init__(self, base, cli):
-        """Initialize the plugin instance."""
-        super(Playground, self).__init__(base, cli)
-        if cli is not None:
-            cli.register_command(PlaygroundCommand)
-
-
+@dnf.plugin.register_command
 class PlaygroundCommand(CoprCommand):
     """ Playground plugin for DNF """
 

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -33,18 +33,7 @@ import os
 import shutil
 
 
-class Download(dnf.Plugin):
-
-    name = 'download'
-
-    def __init__(self, base, cli):
-        super(Download, self).__init__(base, cli)
-        self.base = base
-        self.cli = cli
-        if self.cli is not None:
-            self.cli.register_command(DownloadCommand)
-
-
+@dnf.plugin.register_command
 class DownloadCommand(dnf.cli.Command):
 
     aliases = ['download']

--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -162,16 +162,7 @@ class ProcessStart(object):
         return self.boot_time + secs_after_boot
 
 
-class NeedsRestarting(dnf.Plugin):
-    name = 'needs-restarting'
-
-    def __init__(self, base, cli):
-        super(NeedsRestarting, self).__init__(base, cli)
-        if cli is None:
-            return
-        cli.register_command(NeedsRestartingCommand)
-
-
+@dnf.plugin.register_command
 class NeedsRestartingCommand(dnf.cli.Command):
     aliases = ('needs-restarting',)
     summary = _('determine updated binaries that need restarting')

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -98,18 +98,7 @@ def rpm2py_format(queryformat):
     return fmt
 
 
-class RepoQuery(dnf.Plugin):
-
-    name = 'Query'
-
-    def __init__(self, base, cli):
-        super(RepoQuery, self).__init__(base, cli)
-        self.base = base
-        self.cli = cli
-        if self.cli is not None:
-            self.cli.register_command(RepoQueryCommand)
-
-
+@dnf.plugin.register_command
 class RepoQueryCommand(dnf.cli.Command):
 
     """The util command there is extending the dnf command line."""

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -35,17 +35,7 @@ def _pkgdir(intermediate, target):
     return os.path.normpath(os.path.join(cwd, intermediate, target))
 
 
-class RepoSync(dnf.Plugin):
-
-    name = 'reposync'
-
-    def __init__(self, base, cli):
-        super(RepoSync, self).__init__(base, cli)
-        if cli is None:
-            return
-        cli.register_command(RepoSyncCommand)
-
-
+@dnf.plugin.register_command
 class RepoSyncCommand(dnf.cli.Command):
     aliases = ('reposync',)
     summary = _('download all packages from remote repo')


### PR DESCRIPTION
Depends on rpm-software-management/dnf#478.
Replaces plugin class to register command with simple decorator.