### PR TITLE
Set --alldeps as defaults in repoquery and add --nodeps option

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -23,6 +23,12 @@ Core DNF Plugins Release Notes
 
 
 ====================
+0.1.21 Release Notes
+====================
+
+Setted --alldeps as defaults in Repoquery plugin and added --exactdeps option.
+
+====================
 0.1.20 Release Notes
 ====================
 

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -26,7 +26,7 @@ Core DNF Plugins Release Notes
 0.1.21 Release Notes
 ====================
 
-Setted --alldeps as defaults in Repoquery plugin and added --exactdeps option.
+Set --alldeps as defaults in Repoquery plugin and added --exactdeps option.
 
 ====================
 0.1.20 Release Notes

--- a/doc/repoquery.rst
+++ b/doc/repoquery.rst
@@ -106,7 +106,12 @@ Together with ``<pkg-spec>``, control what packages are displayed in the output.
     Limit the resulting set only to packages that supplement ``<capability>``.
 
 ``--alldeps``
-    This option is stackable with ``--whatrequires`` only. Additionally it adds to the result set all packages requiring the package features.
+    This option is stackable with ``--whatrequires`` only. Additionally it adds to the result set all packages requiring
+    the package features (used as default).
+
+``--nodeps``
+    This option is stackable with ``--whatrequires`` only. Limit the resulting set only to packages that require
+    ``<capability>`` specified by --whatrequires.
 
 ``--srpm``
     Operate on corresponding source RPM.

--- a/plugins/repoquery.py
+++ b/plugins/repoquery.py
@@ -326,9 +326,9 @@ class RepoQueryCommand(dnf.cli.Command):
             q = q.filter(provides__glob=[self.opts.whatprovides])
         if self.opts.alldeps or self.opts.exactdeps:
             if not self.opts.whatrequires:
+                print(self.parser.format_help())
                 raise dnf.exceptions.Error(
-                    _("{} requires --whatrequires option.\n"
-                      "usage: dnf repoquery [--whatrequires] [key] [--alldeps]\n\n".format(
+                    _("argument {} requires --whatrequires option".format(
                         '--alldeps' if self.opts.alldeps else '--exactdeps')))
             if self.opts.alldeps:
                 q = self.by_all_deps(self.opts.whatrequires, q)


### PR DESCRIPTION
It sets --alldeps as default according to yum-dnf compatibility.

It also introduce --nodeps option that represent formal default status of
"dnf repoquery --whatrequires"