### PR TITLE
spec: correctly set up requirements for python subpkg

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -18,7 +18,11 @@ Source0:        %{url}/archive/%{name}-%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  cmake
 BuildRequires:  gettext
-Requires:       python-%{name} = %{version}-%{release}
+%if %{with python3}
+Requires:       python3-%{name} = %{version}-%{release}
+%else
+Requires:       python2-%{name} = %{version}-%{release}
+%endif
 Provides:       dnf-command(builddep)
 Provides:       dnf-command(config-manager)
 Provides:       dnf-command(copr)


### PR DESCRIPTION
Unfortunately %python_provide is still providing py2 package by default
even on f24, f25 (rawhide). So let's require explicitly.

Reference: https://github.com/rpm-software-management/dnf/pull/493
Reported-by: Jaroslav Mracek <jmracek@redhat.com>
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>