### PR TITLE
Fix reading the copr.conf file and add Mageia chroot selection support

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -96,7 +96,7 @@ class CoprCommand(dnf.cli.Command):
 
 
         # Useful for forcing a distribution
-        raw_copr_plugin_config = ConfigParser()
+        copr_plugin_config = ConfigParser()
         config_file = None
         for path in self.base.conf.pluginconfpath:
             test_config_file = '{}/{}.conf'.format(path, PLUGIN_CONF)
@@ -104,15 +104,13 @@ class CoprCommand(dnf.cli.Command):
                 config_file = test_config_file
 
         if config_file is not None:
-            cp = raw_copr_plugin_config.read_file(config_file)
-            distribution = (cp.has_section('main')
-                            and cp.has_option('main', 'distribution')
-                            and cp.get('main', 'distribution'))
-            releasever = (cp.has_section('main')
-                          and cp.has_option('main', 'releasever')
-                          and cp.get('main', 'releasever'))
-            self.chroot_config = [distribution, releasever]
-
+            copr_plugin_config.read(config_file)
+            if copr_plugin_config.has_option('main', 'distribution') and copr_plugin_config.has_option('main', 'releasever'):
+                distribution = copr_plugin_config.get('main', 'distribution')
+                releasever = copr_plugin_config.get('main', 'releasever')
+                self.chroot_config = ["{}".format(distribution), "{}".format(releasever)]
+            else:
+                self.chroot_config = [False, False]
 
     def run(self, extcmds):
         try:

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -109,7 +109,7 @@ class CoprCommand(dnf.cli.Command):
             if copr_plugin_config.has_option('main', 'distribution') and copr_plugin_config.has_option('main', 'releasever'):
                 distribution = copr_plugin_config.get('main', 'distribution')
                 releasever = copr_plugin_config.get('main', 'releasever')
-                self.chroot_config = ["{}".format(distribution), "{}".format(releasever)]
+                self.chroot_config = [distribution, releasever]
             else:
                 self.chroot_config = [False, False]
 
@@ -278,7 +278,7 @@ Do you want to continue? [y/N]: """)
         elif "Mageia" in dist:
             # Detect architecture (Mageia does not use $basearch)
             distarch = platform.machine()
-            if re.match("^i[3-6]86$", distarch, flags=0) is not None:
+            if re.match("^i[3-6]86$", distarch):
                 distarch = "i586"
             if "arm" in distarch:
                 distarch = "armv5tl"

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -31,7 +31,7 @@ import os
 import platform
 import shutil
 import stat
-import re
+import rpm
 
 PLUGIN_CONF = 'copr'
 
@@ -276,12 +276,8 @@ Do you want to continue? [y/N]: """)
             else:
                 chroot = ("fedora-{}-x86_64".format(dist[1]))
         elif "Mageia" in dist:
-            # Detect architecture (Mageia does not use $basearch)
-            distarch = platform.machine()
-            if re.match("^i[3-6]86$", distarch):
-                distarch = "i586"
-            if "arm" in distarch:
-                distarch = "armv5tl"
+            # Get distribution architecture (Mageia does not use $basearch)
+            distarch = rpm.expandMacro("%{distro_arch}")
             # Set the chroot
             if "Cauldron" in dist:
                 chroot = ("mageia-cauldron-{}".format(distarch))

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -31,6 +31,7 @@ import os
 import platform
 import shutil
 import stat
+import re
 
 PLUGIN_CONF = 'copr'
 
@@ -274,6 +275,18 @@ Do you want to continue? [y/N]: """)
                 chroot = ("fedora-rawhide-x86_64")
             else:
                 chroot = ("fedora-{}-x86_64".format(dist[1]))
+        elif "Mageia" in dist:
+            # Detect architecture (Mageia does not use $basearch)
+            distarch = platform.machine()
+            if re.match("^i[3-6]86$", distarch, flags=0) is not None:
+                distarch = "i586"
+            if "arm" in distarch:
+                distarch = "armv5tl"
+            # Set the chroot
+            if "Cauldron" in dist:
+                chroot = ("mageia-cauldron-{}".format(distarch))
+            else:
+                chroot = ("mageia-{0}-{1}".format(dist[1], distarch))
         else:
             chroot = ("epel-%s-x86_64" % dist[1].split(".", 1)[0])
         return chroot


### PR DESCRIPTION
This pull request fixes how `copr.conf` was read so that it doesn't trigger a traceback anymore (reported by Korora's @csmart).

In addition, I've added support for selecting Mageia chroots automatically.

(Obsoletes #169)