### PR TITLE
spec: explicitly conflict with python-%{name} with different version

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -55,6 +55,7 @@ Requires:       python-hawkey >= %{hawkey_version}
 Conflicts:      %{name} <= 0.1.5
 # let the both python plugin versions be updated simultaneously
 Conflicts:      python3-%{name} < %{version}-%{release}
+Conflicts:      python-%{name} < %{version}-%{release}
 
 %description -n python2-%{name}
 Core Plugins for DNF, Python 2 interface. This package enhances DNF with builddep, copr,
@@ -77,6 +78,7 @@ Requires:       python3-hawkey >= %{hawkey_version}
 Conflicts:      %{name} <= 0.1.5
 # let the both python plugin versions be updated simultaneously
 Conflicts:      python2-%{name} < %{version}-%{release}
+Conflicts:      python-%{name} < %{version}-%{release}
 
 %description -n python3-%{name}
 Core Plugins for DNF, Python 3 interface. This package enhances DNF with builddep, copr,


### PR DESCRIPTION
When we have installed python-dnf-plugins-core (before %python_provide) it is
possible to install python3-dnf-plugins-core with new version because it conflicts
with python2-dnf-plugins-core which is not installed. Let's fix it.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>