### PR TITLE
Change usage of add_remote_rpm according to new API

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -182,8 +182,8 @@ class DownloadCommand(dnf.cli.Command):
     def _get_query(self, pkg_spec):
         """Return a query to match a pkg_spec."""
         if os.path.exists(pkg_spec):
-            pkg = self.base.add_remote_rpm(pkg_spec)
-            pkg_spec = "{0.name}-{0.epoch}:{0.version}-{0.release}.{0.arch}".format(pkg)
+            pkgs = self.base.add_remote_rpms([pkg_spec])
+            pkg_spec = "{0.name}-{0.epoch}:{0.version}-{0.release}.{0.arch}".format(pkgs[0])
 
         subj = dnf.subject.Subject(pkg_spec)
         q = subj.get_best_query(self.base.sack)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -230,7 +230,7 @@ class DownloadCommandTest(unittest.TestCase):
         cli = mock.MagicMock()
         self.cmd = download.DownloadCommand(cli)
         self.cmd.cli.base = dnf.cli.cli.BaseCli()
-        self.cmd.cli.base.add_remote_rpm = mock.Mock()
+        self.cmd.cli.base.add_remote_rpms = mock.MagicMock()
         self.cmd.cli.base.download_packages = mock.Mock()
 
         # point the Sack and Subject to out stubs
@@ -304,12 +304,12 @@ class DownloadCommandTest(unittest.TestCase):
     def test_get_query_with_local_rpm(self):
         try:
             (fs, rpm_path) = tempfile.mkstemp('foobar-99.99-1.x86_64.rpm')
-            # b/c self.cmd.cli.base.add_remote_rpm is a mock object it
+            # b/c self.cmd.cli.base.add_remote_rpms is a mock object it
             # will not update the available packages while testing.
             # it is expected to hit this exception
             with self.assertRaises(dnf.exceptions.PackageNotFoundError):
                 self.cmd._get_query(rpm_path)
-            self.cmd.cli.base.add_remote_rpm.assert_called_with(rpm_path)
+            self.cmd.cli.base.add_remote_rpms.assert_called_with([rpm_path])
         finally:
             os.remove(rpm_path)
 


### PR DESCRIPTION
The function add_remote_rpm now requires list of paths and returns list.