### PR TITLE
Adjust to privatization of function from dnf.sack.rpmdb_sack()

### DIFF
--- a/plugins/debuginfo-install.py
+++ b/plugins/debuginfo-install.py
@@ -46,7 +46,7 @@ class DebuginfoInstall(dnf.Plugin):
 
         if autoupdate:
             # allow update of already installed debuginfo packages
-            dbginfo = dnf.sack.rpmdb_sack(self.base).query().filter(
+            dbginfo = dnf.sack._rpmdb_sack(self.base).query().filter(
                                                 name__glob="*-debuginfo")
             if len(dbginfo):
                 self.base.repos.enable_debug_repos()


### PR DESCRIPTION
To make more distinguishable API and private functions the def rpmdb_sack was
renamed to _rpmdb_sack, therefore it has to be reflected in DNF-core.