### PR TITLE
Change name of dnf call

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -35,7 +35,7 @@ else:
 
 def command_configure(cmd, args):
     parser = dnf.cli.option_parser.OptionParser()
-    args = [cmd.basecmd] + args
+    args = [cmd._basecmd] + args
     parser.parse_main_args(args)
     parser.parse_command_args(cmd, args)
     return cmd.configure()


### PR DESCRIPTION
The change is required by privatization of non-API functions.