### PR TITLE
Change minimal required version

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 1.1.9}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 2.0.0}
 %{?!dnf_not_compatible: %global dnf_not_compatible 3.0}
 %global hawkey_version 0.7.0
 


### PR DESCRIPTION
If from dnf 2.0 downgrade to 1.9 it has to requires downgrade of
dnf-plugins-core. The patch should provides the behavior.