### PR TITLE
cls.chroot_config inside _guess_chroot returns None (RhBug: 1361003)

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -136,7 +136,7 @@ class CoprCommand(dnf.cli.Command):
         try:
             chroot = extcmds[2]
         except IndexError:
-            chroot = self._guess_chroot()
+            chroot = self._guess_chroot(self.chroot_config)
 
         # commands without defined copr_username/copr_projectname
         if subcommand == "list":
@@ -261,11 +261,11 @@ Do you want to continue? [y/N]: """)
             raise dnf.exceptions.Error(
                 _('This command has to be run under the root user.'))
 
-    @classmethod
-    def _guess_chroot(cls):
+    @staticmethod
+    def _guess_chroot(chroot_config):
         """ Guess which chroot is equivalent to this machine """
         # FIXME Copr should generate non-specific arch repo
-        dist = cls.chroot_config
+        dist = chroot_config
         if dist is None or (dist[0] is False) or (dist[1] is False):
             dist = platform.linux_distribution()
         if "Fedora" in dist:
@@ -289,7 +289,7 @@ Do you want to continue? [y/N]: """)
 
     def _download_repo(self, project_name, repo_filename, chroot=None):
         if chroot is None:
-            chroot = self._guess_chroot()
+            chroot = self._guess_chroot(self.chroot_config)
         short_chroot = '-'.join(chroot.split('-')[:2])
         #http://copr.fedorainfracloud.org/coprs/larsks/rcm/repo/epel-7-x86_64/
         api_path = "/coprs/{0}/repo/{1}/".format(project_name, short_chroot)
@@ -434,7 +434,7 @@ Do you want to continue? [y/N]: """)
             raise dnf.cli.CliError(
                 _('exactly one parameter to '
                   'playground command is required'))
-        chroot = self._guess_chroot()
+        chroot = self._guess_chroot(self.chroot_config)
         if subcommand == "enable":
             self._cmd_enable(chroot)
             logger.info(_("Playground repositories successfully enabled."))


### PR DESCRIPTION
Redo of failed PR rpm-software-management/dnf-plugins-core#188 which was against master instead of dnf-1.1 branch. 

@Conan-Kudo 
@ignatenkobrain 

-----

##### Original Post:

1. L#259: cls.chroot_config returns None
2. L#107: self.chroot_config is defined properly but is not passed to
_guess_chroot()
   - self changed to class identifier CoprCommand - works

Disclaimer: I am not a Python developer and I merely stumbled on a solution that worked for me. I verified with `pdb` that the necessary values were being passed correctly before submitting the patch. I have no idea why the original code doesn't work versus specifying the class name. 

My personal use case is Fedy on Korora. Fedy relies on some COPR repositories, and it is completely broken right now (that is, all COPR repos on any system that needs to use `/etc/dnf/plugins/copr.conf` don't currently work because `dnf copr` returns that it can not find any builds

```
Error: This repository does not have any builds yet so you cannot enable it now. 
```

https://bugzilla.redhat.com/show_bug.cgi?id=1361003