### PR TITLE
builddep: adjust to new config (dnf-2.0)

### DIFF
--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -145,7 +145,7 @@ class BuildDepCommand(dnf.cli.Command):
 
     def _src_deps(self, src_fn):
         fd = os.open(src_fn, os.O_RDONLY)
-        if self.cli.nogpgcheck:
+        if not self.base.conf.gpgcheck:
             self.rpm_ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
         try:
             h = self.rpm_ts.hdrFromFdno(fd)

--- a/tests/support.py
+++ b/tests/support.py
@@ -83,8 +83,6 @@ class BaseCliStub(object):
 class CliStub(object):
     """A class mocking `dnf.cli.Cli`."""
 
-    nogpgcheck = True
-
     def __init__(self, base):
         """Initialize the CLI."""
         self.base = base
@@ -100,6 +98,56 @@ class CliStub(object):
 
 class DemandsStub(object):
     pass
+
+
+class FakeConf(dnf.conf.Conf):
+    def __init__(self, **kwargs):
+        super(FakeConf, self).__init__()
+        self.substitutions['releasever'] = 'Fedora69'
+        for optname, val in [
+                ('assumeyes', None),
+                ('best', False),
+                ('cachedir', dnf.const.TMPDIR),
+                ('clean_requirements_on_remove', False),
+                ('color', 'never'),
+                ('color_update_installed', 'normal'),
+                ('color_update_remote', 'normal'),
+                ('color_list_available_downgrade', 'dim'),
+                ('color_list_available_install', 'normal'),
+                ('color_list_available_reinstall', 'bold'),
+                ('color_list_available_upgrade', 'bold'),
+                ('color_list_installed_extra', 'bold'),
+                ('color_list_installed_newer', 'bold'),
+                ('color_list_installed_older', 'bold'),
+                ('color_list_installed_reinstall', 'normal'),
+                ('color_update_local', 'bold'),
+                ('debug_solver', False),
+                ('debuglevel', 2),
+                ('defaultyes', False),
+                ('disable_excludes', []),
+                ('diskspacecheck', True),
+                ('exclude', []),
+                ('include', []),
+                ('install_weak_deps', True),
+                ('history_record', False),
+                ('installonly_limit', 0),
+                ('installonlypkgs', ['kernel']),
+                ('installroot', '/'),
+                ('ip_resolve', None),
+                ('multilib_policy', 'best'),
+                ('obsoletes', True),
+                ('persistdir', '/should-not-exist-bad-test/persist'),
+                ('protected_packages', ["dnf"]),
+                ('plugins', False),
+                ('showdupesfromrepos', False),
+                ('tsflags', []),
+                ('strict', True),
+                ] + list(kwargs.items()):
+            setattr(self, optname, dnf.conf.Value(val, dnf.conf.PRIO_DEFAULT))
+
+    @property
+    def releasever(self):
+        return self.substitutions['releasever']
 
 
 class RepoStub(object):

--- a/tests/test_builddep.py
+++ b/tests/test_builddep.py
@@ -32,6 +32,7 @@ class MockBase(object):
     def __init__(self):
         self.marked = []
         self.repos = dnf.repodict.RepoDict()
+        self.conf = support.FakeConf()
 
     def install(self, spec):
         self.marked.append(spec)


### PR DESCRIPTION
The builddep plugin stopped working after 1679f9f6.