### PR TITLE
dnf dowload --resolve should download everytime requested packages (RhBug:1276611)

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -58,6 +58,9 @@ Options
 ``--urlprotocol``
     Limit the protocol of the urls output by the --url option. Options are http, https, rsync, ftp.
 
+``--resolve``
+    Resolves dependencies of specified packages and downloads missing dependencies in the system.
+
 --------
 Examples
 --------

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -217,8 +217,11 @@ class DownloadCommand(dnf.cli.Command):
             goal.install(pkg)
         rc = goal.run()
         if rc:
-            pkgs = goal.list_installs() + goal.list_upgrades()
-            return pkgs
+            new_pkgs = goal.list_installs() + goal.list_upgrades()
+            for pkg in pkgs:
+                if pkg not in new_pkgs:
+                    new_pkgs += [pkg]
+            return new_pkgs
         else:
             logger.debug(_('Error in resolve'))
             return []

--- a/plugins/download.py
+++ b/plugins/download.py
@@ -217,7 +217,7 @@ class DownloadCommand(dnf.cli.Command):
             goal.install(pkg)
         rc = goal.run()
         if rc:
-            pkgs = goal.list_installs()
+            pkgs = goal.list_installs() + goal.list_upgrades()
             return pkgs
         else:
             logger.debug(_('Error in resolve'))


### PR DESCRIPTION
dnf download --resolve should download packages that are already installed with lower version and are marked as upgrade

References: https://bugzilla.redhat.com/show_bug.cgi?id=1276611
