### PR TITLE
update link to "What I can build in Copr? documentation page

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -156,8 +156,8 @@ repository is not part of the main distribution, and quality may vary.
 
 The Fedora Project does not exercise any power over the contents of
 this repository beyond the rules outlined in the Copr FAQ at
-<https://fedorahosted.org/copr/wiki/UserDocs#WhatIcanbuildinCopr>, and
-packages are not held to any quality or security level.
+<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
+and packages are not held to any quality or security level.
 
 Please do not file bug reports about these packages in Fedora
 Bugzilla. In case of problems, contact the owner of this repository.


### PR DESCRIPTION
Hello, this PR updates link from (retired) fedorahosted.org documentation page to pagure.io page.