### PR TITLE
Download plugin: Move --destdir to dnf (RhBug:1279001)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 2.6.0}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 2.6.1}
 %{?!dnf_not_compatible: %global dnf_not_compatible 3.0}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.7.0
@@ -10,7 +10,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        2.1.2
+Version:        2.1.3
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+


### PR DESCRIPTION
Because we can't define CLI option --destdir twice (once in download plugin, once in dnf), I moved the copying functionality to dnf and made download plugin use it.

This pull request and the [pull request for dnf](https://github.com/rpm-software-management/dnf/pull/810) have to be accepted at the same time, because one doesn't work without the other (breaks download plugin).

Because --destdir will be run under root, all downloaded (to another location) packages now have permissions set to 777 since most expected usecases involve a non-privileged user doing something with the files (probably moving).