### PR TITLE
copr: added list command to show enabled Copr repositories

### DIFF
--- a/doc/copr.rst
+++ b/doc/copr.rst
@@ -28,7 +28,7 @@ Work with Copr & Playground repositories on the local system.
 Synopsis
 --------
 
-``dnf copr [enable|disable|remove|list|search] <parameters>``
+``dnf copr [enable|disable|remove|list|list-user|search] <parameters>``
 
 ``dnf playground [enable|disable|upgrade]``
 
@@ -45,7 +45,10 @@ Arguments (copr)
 ``remove name/project``
     Remove the ``name/project`` Copr repository.
 
-``list name``
+``list``
+    List enabled Copr repositories.
+
+``list-user name``
     List available Copr repositories for a given ``name``.
 
 ``search project``
@@ -74,7 +77,7 @@ Examples
 ``copr disable rhscl/perl516``
     Disable the ``rhscl/perl516`` Copr repository
 
-``copr list rita``
+``copr list-user rita``
     List available Copr projects for user ``rita``.
 
 ``copr search tests``

--- a/doc/copr.rst
+++ b/doc/copr.rst
@@ -28,7 +28,7 @@ Work with Copr & Playground repositories on the local system.
 Synopsis
 --------
 
-``dnf copr [enable|disable|remove|list|list-user|search] <parameters>``
+``dnf copr [enable|disable|remove|list|search] <parameters>``
 
 ``dnf playground [enable|disable|upgrade]``
 
@@ -45,10 +45,16 @@ Arguments (copr)
 ``remove name/project``
     Remove the ``name/project`` Copr repository.
 
-``list``
+``list --installed``
+    List installed Copr repositories (default).
+
+``list --enabled``
     List enabled Copr repositories.
 
-``list-user name``
+``list --disabled``
+    List disabled Copr repositories.
+
+``list --available-by-user=name``
     List available Copr repositories for a given ``name``.
 
 ``search project``
@@ -77,7 +83,7 @@ Examples
 ``copr disable rhscl/perl516``
     Disable the ``rhscl/perl516`` Copr repository
 
-``copr list-user rita``
+``copr list --available-by-user=rita``
     List available Copr projects for user ``rita``.
 
 ``copr search tests``

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -204,20 +204,15 @@ Do you want to continue?""")
                     parser.read(directory + '/' + file_name)
 
         for copr in parser.sections():
-            if parser.getboolean(copr, "enabled"):
-                if disabled_only:
-                    pass
-                else:
-                    copr_name = copr.split('-', 1)
-                    msg = copr_name[0] + '/' + copr_name[1]
-                    print(msg)
-            elif not parser.getboolean(copr, "enabled"):
-                if enabled_only:
-                    pass
-                else:
-                    copr_name = copr.split('-', 1)
-                    msg = copr_name[0] + '/' + copr_name[1] + " (disabled)"
-                    print(msg)
+            enabled = parser.getboolean(copr, "enabled")
+            if (enabled and disabled_only) or (not enabled and enabled_only):
+               continue
+
+            copr_name = copr.split('-', 1)
+            msg = copr_name[0] + '/' + copr_name[1]
+            if not enabled:
+                msg += " (disabled)"
+            print(msg)
 
     def _list_user_projects(self, user_name):
         # http://copr.fedorainfracloud.org/api/coprs/ignatenkobrain/

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -206,7 +206,7 @@ Do you want to continue?""")
         for copr in parser.sections():
             enabled = parser.getboolean(copr, "enabled")
             if (enabled and disabled_only) or (not enabled and enabled_only):
-               continue
+                continue
 
             copr_name = copr.split('-', 1)
             msg = copr_name[0] + '/' + copr_name[1]

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -129,7 +129,7 @@ class CoprCommand(dnf.cli.Command):
                 return
             else:
                 self._list_installed_repositories(self.base.conf.reposdir[0],
-                    self.opts.enabled, self.opts.disabled)
+                                                  self.opts.enabled, self.opts.disabled)
                 return
 
         try:
@@ -195,7 +195,6 @@ Do you want to continue?""")
             raise dnf.exceptions.Error(
                 _('Unknown subcommand {}.').format(subcommand))
 
-
     def _list_installed_repositories(self, directory, enabled_only, disabled_only):
         parser = ConfigParser()
 
@@ -219,7 +218,6 @@ Do you want to continue?""")
                     copr_name = copr.split('-', 1)
                     msg = copr_name[0] + '/' + copr_name[1] + " (disabled)"
                     print(msg)
-
 
     def _list_user_projects(self, user_name):
         # http://copr.fedorainfracloud.org/api/coprs/ignatenkobrain/


### PR DESCRIPTION
Adds ``dnf copr list`` subcommand to show enabled Copr repositories. Changes the original ``dnf copr list name`` subcommand (which lists available Copr repositories for a given ``name``) to ``dnf copr list-user name``.