### PR TITLE
Rename --destdir to --downloaddir in doc

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -49,7 +49,7 @@ Options
 ``--debuginfo``
     Download the debuginfo rpm. Enables debuginfo repositories of all enabled binary repositories.
 
-``--destdir``
+``--downloaddir``
     Download directory, default is the current directory (the directory must exist).
 
 ``--url``


### PR DESCRIPTION
This will unify documentation of options with dnf core where downloaddir option
is described. Both options remain as aliases, but it should provide better user
experiences.