### PR TITLE
Fix repoclosure --check interaction with --best

### DIFF
--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -94,6 +94,9 @@ class RepoClosureCommand(dnf.cli.Command):
                 for pkgs_filtered in available.filter(reponame=repo):
                     checkpkgs.add(pkgs_filtered)
             pkgs.intersection_update(checkpkgs)
+            # --best not applied earlier due to --check, so do it now
+            if self.base.conf.best:
+                available = available.latest()
 
         for pkg in pkgs:
             unresolved[pkg] = set()


### PR DESCRIPTION
This is a follow-up of rpm-software-management/dnf-plugins-extras/pull/50

With `--check`, we want to check repo closure for all packages in the specified repositories.

With `--best`, we want to only use the latest versions of each package across all repos.

When using both options, we need to enumerate the packages to be checked from the `--check` repos before reducing the package set to the latest versions for `--best`, as that might eliminate some of the packages from the `--check` repos. The existing code already inhibits using `available.latest()` early on for `--best` when using `--check`, and this commit does the deferred application of `available.latest()` for the case when `--check` and `--best` are used together.

I would like to write a test case for this but can't get my head around how to do it. It really needs two repos, and the existing tests only seem to be using `@commandline`. The main `dnf` test code appears to have infrastructure for mock repos with dummy packages and dependencies but I'm afraid I can't figure out how it works or how much code would need to be copied from there to do what I want. Maybe at some point in the future there could be some common test infrastructure packaged with `dnf` that plugins could use?