### PR TITLE
AUTHORS: add leaves author

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,6 +2,7 @@
 DNF-PLUGINS-CORE AUTHORS
 ------------------------
     Ales Kozumplik <ales@redhat.com>
+    Emil Renner Berthing <dnf@esmil.dk>
     Igor Gnatenko <i.gnatenko.brain@gmail.com>
     Jan Silhan <jsilhan@redhat.com>
     Michael Mraka <michael.mraka@redhat.com>


### PR DESCRIPTION
I think you forgot me when copying the leaves plugin from dnf-plugin-extras