### PR TITLE
Add hint for --arch options (RhBug:1489724)

### DIFF
--- a/doc/download.rst
+++ b/doc/download.rst
@@ -43,6 +43,11 @@ Options
 ``--help-cmd``
     Show this help.
 
+``--arch <arch>[,<arch>...]``
+    Limit the query to packages of given architectures (default is all compatible architectures with
+    your system). To download packages with arch incompatible with your system use
+    ``--forcearch=<arch>`` option to change basearch.
+
 ``--source``
     Download the source rpm. Enables source repositories of all enabled binary repositories.
 

--- a/doc/repoclosure.rst
+++ b/doc/repoclosure.rst
@@ -38,7 +38,9 @@ Options
 -------
 
 ``--arch <arch>``
-    Query only packages for specified architecture, can be specified multiple times (default is all architectures).
+    Query only packages for specified architecture, can be specified multiple times (default is all
+    compatible architectures with your system). To run repoclosure for arch incompatible with your
+    system use ``--forcearch=<arch>`` option to change basearch.
 
 ``--best``
     Check only the newest packages per arch.


### PR DESCRIPTION
It adds description of arch option for download command.

It also adds hint about --forcearch option for repoclosure because in some cases
users can be confused by --arch option.

https://bugzilla.redhat.com/show_bug.cgi?id=1489724