### PR TITLE
Enable JSON output option in repoclosure plugin

### DIFF
--- a/doc/repoclosure.rst
+++ b/doc/repoclosure.rst
@@ -57,6 +57,9 @@ Options
 ``--repo <repoid>``
     Specify repo ids to query, can be specified multiple times (default is all enabled).
 
+``--json-output``
+    Outputs the list of unresolved package dependencies as JSON for use in scripts
+
 
 --------
 Examples


### PR DESCRIPTION
- add --json-output option which outputs JSON that is
  readable by those writing scripts against the output
  from the repoclosure plugin
- update the documentation to reflect the new feature

Signed-off-by: Robert Marshall <rmarshall@redhat.com>