### PR TITLE
Reposync: compatibility with yum-utils version (RhBug:1405789)

### DIFF
--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -76,8 +76,11 @@ class RepoSyncCommand(dnf.cli.Command):
         if self.opts.source:
             repos.enable_source_repos()
 
+        self._repo_base_path = dict()
         for repo in repos.iter_enabled():
-            repo.pkgdir = _pkgdir(self.opts.download_path, repo.id)
+            path = _pkgdir(self.opts.download_path, repo.id)
+            self._repo_base_path[repo.id] = path
+            repo.pkgdir = os.path.join(path, 'Packages')
 
     def delete_old_local_packages(self, packages_to_download):
         download_map = dict()
@@ -106,7 +109,7 @@ class RepoSyncCommand(dnf.cli.Command):
                     except IOError:
                         logger.error(_("Could not make repository directory: %s"), repo.pkgdir)
                         sys.exit(1)
-                dest = os.path.join(repo.pkgdir, 'comps.xml')
+                dest = os.path.join(self._repo_base_path[repo.id], 'comps.xml')
                 dnf.yum.misc.decompress(comps_fn, dest=dest)
                 logger.info(_("comps.xml for repository %s saved"), repo.id)
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1405789

Added functionality:
* option --newest-only to download only newest packages per repo
* option --delete to delete local packages no longer present in repository
* option --downloadcomps to download comps.xml file for repos
* option --arch for filtering packages by architecture
* option --source to operate on source packages