### PR TITLE
versionlock: delete was not operating on excludes

### DIFF
--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -200,7 +200,7 @@ def _write_locklist(base, args, try_installed, comment, info, prefix):
 
 def _match(ent, patterns):
     try:
-        n = hawkey.split_nevra(ent)
+        n = hawkey.split_nevra(ent.lstrip('!'))
     except hawkey.ValueException:
         return False
     for name in (


### PR DESCRIPTION
once package was excluded, there was no way to remove it from
versionlock.list file. Except of dnf versionlock clear of course.