### PR TITLE
Add sentence about security updates

### DIFF
--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -33,7 +33,7 @@ Description
 
 `needs-restarting` looks through running processes and tries to detect those that use files from packages that have been updated after the given process started. Such processes are reported by this tool.
 
-Note that in most cases a process should survive update of its binary and libraries it is using without requiring to be restarted for proper operation. There are however specific cases when this does not apply.
+Note that in most cases a process should survive update of its binary and libraries it is using without requiring to be restarted for proper operation. There are however specific cases when this does not apply. Separately, processes often need to be restarted to reflect security updates.
 
 -------
 Options


### PR DESCRIPTION
Users often need to determine what processes require restarting because of security updates to shared libraries and the like. This really merits mentioning to reinforce this practice.