### PR TITLE
Note versionlock works on packages absent from repos (RhBug:1431491)

### DIFF
--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -99,3 +99,12 @@ The minimal content of conf file should contain ``main`` sections with ``enabled
       The file takes entries in the format of ``package-spec`` (optionally prefixed with '!' for
       excludes).
       See :ref:`\specifying_packages-label`.
+
+-----
+Notes
+-----
+
+A specified package does not have to exist within the available cache of repository data
+to be considered valid for locking or exclusion. This is by design, to accommodate use
+cases such as local custom packages, or those intentionally retained from a prior release
+or a presently disabled repository.

--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -106,5 +106,5 @@ Notes
 
 A specified package does not have to exist within the available cache of repository data
 to be considered valid for locking or exclusion. This is by design, to accommodate use
-cases such as local custom packages, or those intentionally retained from a prior release
-or a presently disabled repository.
+cases such as a presently disabled repository. However, a package must exist in the
+repository cache when the ``add`` or ``exclude`` subcommands are invoked for it.


### PR DESCRIPTION
Adding a note about the resolution of https://bugzilla.redhat.com/show_bug.cgi?id=1431491. (I'd tripped over this myself before.)