### PR TITLE
Bump dnf max compatible version

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,5 +1,5 @@
 %{?!dnf_lowest_compatible: %global dnf_lowest_compatible 2.8.1}
-%{?!dnf_not_compatible: %global dnf_not_compatible 3.0}
+%{?!dnf_not_compatible: %global dnf_not_compatible 4.0}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.7.0
 


### PR DESCRIPTION
Required for: https://github.com/rpm-software-management/libdnf/pull/433