### PR TITLE
copr: Add openSUSE support

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -300,6 +300,14 @@ Do you want to continue?""")
                 chroot = ("mageia-cauldron-{}".format(distarch))
             else:
                 chroot = ("mageia-{0}-{1}".format(dist[1], distarch))
+        elif "openSUSE" in dist:
+            # Get distribution architecture (openSUSE does not use $basearch)
+            distarch = rpm.expandMacro("%{target_cpu}")
+            # Set the chroot
+            if "Tumbleweed" in dist:
+                chroot = ("opensuse-tumbleweed-{}".format(distarch))
+            else:
+                chroot = ("opensuse-leap-{0}-{1}".format(dist[1], distarch))
         else:
             chroot = ("epel-%s-x86_64" % dist[1].split(".", 1)[0])
         return chroot


### PR DESCRIPTION
This PR adds support for detecting openSUSE Leap and Tumbleweed and setting the correct default based on that.

This is required for [RH#1570418](https://bugzilla.redhat.com/show_bug.cgi?id=1570418).