### PR TITLE
repoclosure on non-existing package ends with error (RhBug:1571622)

### DIFF
--- a/doc/repoclosure.rst
+++ b/doc/repoclosure.rst
@@ -51,7 +51,7 @@ Options
 ``--newest``
     Check only the newest packages in the repos.
 
-``--pkg <pkg``
+``--pkg <pkg-spec>``
     Check closure for this package only.
 
 ``--repo <repoid>``

--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -105,7 +105,10 @@ class RepoClosureCommand(dnf.cli.Command):
             pkglist_q = self.base.sack.query().filter(empty=True)
             errors = []
             for pkg in self.opts.pkglist:
-                pkg_q = to_check.filter(name=pkg)
+                subj = dnf.subject.Subject(pkg)
+                pkg_q = to_check.intersection(
+                    subj.get_best_query(self.base.sack, with_nevra=True,
+                                        with_provides=False, with_filenames=False))
                 if pkg_q:
                     pkglist_q = pkglist_q.union(pkg_q)
                 else:

--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -103,6 +103,9 @@ class RepoClosureCommand(dnf.cli.Command):
 
         if self.opts.pkglist:
             to_check = to_check.filter(name=self.opts.pkglist)
+            if not to_check:
+                raise dnf.exceptions.Error(
+                    _('no package matched: %s') % ', '.join(self.opts.pkglist))
 
         if self.opts.check:
             to_check = to_check.filter(reponame=self.opts.check)


### PR DESCRIPTION
When the repoclosure command gets non-existing package in the --pkg option,
it shows an error message and returns error code.

https://bugzilla.redhat.com/show_bug.cgi?id=1571622