### PR TITLE
use up-to-date rpmdb for generating completion cache (RhBug:1505035)

### DIFF
--- a/plugins/generate_completion_cache.py
+++ b/plugins/generate_completion_cache.py
@@ -79,7 +79,7 @@ class BashCompletionCache(dnf.Plugin):
                     "create unique index if not exists "
                     "pkg_installed ON installed(pkg)")
                 cur.execute("delete from installed")
-                inst_pkgs = self.base.sack.query().installed()
+                inst_pkgs = dnf.sack._rpmdb_sack(self.base).query().installed()
                 inst_pkgs_insert = [[str(x)] for x in inst_pkgs if x.arch != "src"]
                 cur.executemany("insert or ignore into installed values (?)",
                                 inst_pkgs_insert)


### PR DESCRIPTION
The rpmdb has changed in the transaction, we need to use a new sack to get
list of installed packages.

https://bugzilla.redhat.com/show_bug.cgi?id=1505035