### PR TITLE
Add provide of yum-utils

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -138,6 +138,9 @@ reposync commands. Additionally provides generate_completion_cache passive plugi
 
 %package -n dnf-utils
 Conflicts:      yum-utils < 1.1.31-513
+%if 0%{?rhel} != 7
+Provides:       yum-utils = %{version}-%{release}
+%endif
 Requires:       dnf >= %{dnf_lowest_compatible}
 Requires:       %{name} = %{version}-%{release}
 %if %{with python3}


### PR DESCRIPTION
Due to conflict of dnf-2.8.9+ with yum, it is nice to provide yum-utils due to
increase compatibility and not breaking work-flows.