### PR TITLE
Minor clarifications for doc/versionlock.rst

### DIFF
--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -40,9 +40,9 @@ installed packages), but dnf will still see the versions you have
 installed/versionlocked as available so that `dnf reinstall` will still
 work, etc.
 
-It can also work in the opposite way, like a fast exclude,
-by prefixing a '!' character to the version. This specifically excludes a package
-that matches the version exactly.
+It can also work in the opposite way, like a fast exclude, by prefixing a '!'
+character to the version recorded in the lock list file. This specifically
+excludes a package that matches the version exactly.
 
 Note the versionlock plugin does not apply any excludes in non-transactional
 operations like `repoquery`, `list`, `info`, etc.

--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -35,7 +35,7 @@ list of locked packages easily.
 The plugin will walk each line of the versionlock file, and parse out the name and
 version of the package. It will then exclude any package by that name that
 doesn't match one of the versions listed within the file. This is basically
-the same as doing an exclude for the package name itself (as you cannot exclude
+the same as using `dnf --exclude` for the package name itself (as you cannot exclude
 installed packages), but dnf will still see the versions you have
 installed/versionlocked as available so that `dnf reinstall` will still
 work, etc.


### PR DESCRIPTION
I've made two minor clarifications to doc/versionlock.rst. In one case (the sentence about "an exclude for the package name itself"), I'm assuming I've got the meaning correct. If not, I submitted these as two commits so the second is easier to back out.