### PR TITLE
Fix RepoStub in unit tests

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -91,7 +91,7 @@ class BaseCliStub(object):
 
     def read_all_repos(self):
         """Read repositories information."""
-        self.repos.add(RepoStub('main'))
+        self.repos.add(dnf.repo.Repo(name='main'))
 
     def read_comps(self):
         """Read groups information."""
@@ -171,28 +171,6 @@ class FakeConf(dnf.conf.Conf):
     def releasever(self):
         return self.substitutions['releasever']
 
-
-class RepoStub(object):
-    """A class mocking `dnf.repo.Repo`"""
-
-    enabled = True
-
-    def __init__(self, id_):
-        """Initialize the repository."""
-        self.id = id_
-        self.priority = 99
-        self.cost = 1000
-
-    def _valid(self):
-        """Return a message if the repository is not valid."""
-
-    def enable(self):
-        """Enable the repo"""
-        self.enabled = True
-
-    def disable(self):
-        """Disable the repo"""
-        self.enabled = False
 
 class TestCase(unittest.TestCase):
     def assertEmpty(self, collection):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests.support import command_run, mock, RepoStub
+from tests.support import command_run, mock
 
 import config_manager
 import dnf

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -17,9 +17,10 @@
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from tests.support import mock, RepoStub
+from tests.support import mock
 
 import dnf.cli
+import dnf.repo
 import dnf.repodict
 import dnf.sack
 import dnf.subject
@@ -275,19 +276,19 @@ class DownloadCommandTest(unittest.TestCase):
         self.cmd.opts = mock.Mock()
         self.cmd.opts.resolve = False
         self.cmd.opts.arches = []
-        repo = RepoStub('foo')
+        repo = dnf.repo.Repo(name='foo')
         repo.enable()
         self.cmd.base.repos.add(repo)
-        repo = RepoStub('foo-source')
+        repo = dnf.repo.Repo(name='foo-source')
         repo.disable()
         self.cmd.base.repos.add(repo)
-        repo = RepoStub('bar')
+        repo = dnf.repo.Repo(name='bar')
         repo.enable()
         self.cmd.base.repos.add(repo)
-        repo = RepoStub('foobar-source')
+        repo = dnf.repo.Repo(name='foobar-source')
         repo.disable()
         self.cmd.base.repos.add(repo)
-        repo = RepoStub('foo-debuginfo')
+        repo = dnf.repo.Repo(name='foo-debuginfo')
         repo.disable()
         self.cmd.base.repos.add(repo)
 

--- a/tests/test_repoclosure.py
+++ b/tests/test_repoclosure.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 from tests.support import mock
 
 import dnf.pycomp
+import dnf.repo
 import os
 import repoclosure
 import tests.support as support
@@ -34,15 +35,15 @@ class TestRepoClosureFunctions(support.TestCase):
 
     def test_repoid_option(self):
         args = ["--repo", "main"]
-        self.cmd.base.repos.add(support.RepoStub("main"))
-        self.cmd.base.repos.add(support.RepoStub("main_fail"))
+        self.cmd.base.repos.add(dnf.repo.Repo(name="main"))
+        self.cmd.base.repos.add(dnf.repo.Repo(name="main_fail"))
         support.command_configure(self.cmd, args)
         repos = [repo.id for repo in self.cmd.base.repos.iter_enabled()]
         self.assertEqual(["main"], repos)
 
     def test_check_option(self):
         args = ["--check", "@commandline"]
-        self.cmd.base.repos.add(support.RepoStub("main"))
+        self.cmd.base.repos.add(dnf.repo.Repo(name="main"))
         self.cmd.base.add_remote_rpms([os.path.join(self.path, "noarch/foo-4-6.noarch.rpm")])
         with mock.patch("sys.stdout", new_callable=dnf.pycomp.StringIO) as stdout:
             with self.assertRaises(dnf.exceptions.Error) as context:

--- a/tests/test_repograph.py
+++ b/tests/test_repograph.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 from tests.support import mock
 
 import dnf.pycomp
+import dnf.repo
 import os
 import repograph
 import tests.support as support
@@ -34,8 +35,8 @@ class TestRepoGraphFunctions(support.TestCase):
 
     def test_repoid_option(self):
         args = ["--repo", "main"]
-        self.cmd.base.repos.add(support.RepoStub("main"))
-        self.cmd.base.repos.add(support.RepoStub("main_fail"))
+        self.cmd.base.repos.add(dnf.repo.Repo(name="main"))
+        self.cmd.base.repos.add(dnf.repo.Repo(name="main_fail"))
         support.command_configure(self.cmd, args)
         repos = [repo.id for repo in self.cmd.base.repos.iter_enabled()]
         self.assertEqual(["main"], repos)

--- a/tests/test_reposync.py
+++ b/tests/test_reposync.py
@@ -20,11 +20,13 @@ from __future__ import unicode_literals
 from tests import support
 import reposync
 
+import dnf.repo
+
 class TestReposyncFunctions(support.TestCase):
     def test_parse_args(self):
         cli = support.CliStub(support.BaseCliStub())
-        cli.base.repos.add(support.RepoStub('silver'))
-        cli.base.repos.add(support.RepoStub('screen'))
+        cli.base.repos.add(dnf.repo.Repo(name='silver'))
+        cli.base.repos.add(dnf.repo.Repo(name='screen'))
         cmd = reposync.RepoSyncCommand(cli)
         args = '-p /become/legend --repo=silver --repo=screen'.split()
         support.command_configure(cmd, args)


### PR DESCRIPTION
RepoStub inherits methods from dnf.repo.Repo instead of faking them.
It is required due to changes in DNF.