### PR TITLE
Compat fixes for dnf-utils

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -442,6 +442,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_mandir}/man1/yum-config-manager.*
 %{_mandir}/man1/yum-debug-dump.*
 %{_mandir}/man1/yum-debug-restore.*
+%{_mandir}/man1/yumdownloader.*
 %else
 %exclude %{_mandir}/man8/yum-copr.*
 %exclude %{_mandir}/man1/debuginfo-install.*
@@ -454,6 +455,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %exclude %{_mandir}/man1/yum-config-manager.*
 %exclude %{_mandir}/man1/yum-debug-dump.*
 %exclude %{_mandir}/man1/yum-debug-restore.*
+%exclude %{_mandir}/man1/yumdownloader.*
 %endif
 
 %if %{with python2}

--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -533,9 +533,11 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_bindir}/yum-debug-dump
 %{_bindir}/yum-debug-restore
 %{_bindir}/yumdownloader
+%{_mandir}/man1/package-cleanup.*
 %{_mandir}/man1/dnf-utils.*
 %{_mandir}/man1/yum-utils.*
 %else
+%exclude %{_mandir}/man1/package-cleanup.*
 %exclude %{_mandir}/man1/dnf-utils.*
 %endif
 

--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -406,6 +406,7 @@ ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-config-manager
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-debug-dump
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-debug-restore
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yumdownloader
+ln -sf %{_mandir}/man1/dnf-utils.1.gz %{buildroot}%{_mandir}/man1/yum-utils.1.gz
 %endif
 
 %check
@@ -530,6 +531,10 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_bindir}/yum-debug-dump
 %{_bindir}/yum-debug-restore
 %{_bindir}/yumdownloader
+%{_mandir}/man1/dnf-utils.*
+%{_mandir}/man1/yum-utils.*
+%else
+%exclude %{_mandir}/man1/dnf-utils.*
 %endif
 
 %if 0%{?rhel} == 0

--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -435,33 +435,6 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_mandir}/man8/dnf.plugin.repograph.*
 %{_mandir}/man8/dnf.plugin.repomanage.*
 %{_mandir}/man8/dnf.plugin.reposync.*
-%if %{with yumcompatibility}
-%{_mandir}/man8/yum-copr.*
-%{_mandir}/man1/debuginfo-install.*
-%{_mandir}/man1/needs-restarting.*
-%{_mandir}/man1/repo-graph.*
-%{_mandir}/man1/repoclosure.*
-%{_mandir}/man1/repomanage.*
-%{_mandir}/man1/reposync.*
-%{_mandir}/man1/yum-builddep.*
-%{_mandir}/man1/yum-config-manager.*
-%{_mandir}/man1/yum-debug-dump.*
-%{_mandir}/man1/yum-debug-restore.*
-%{_mandir}/man1/yumdownloader.*
-%else
-%exclude %{_mandir}/man8/yum-copr.*
-%exclude %{_mandir}/man1/debuginfo-install.*
-%exclude %{_mandir}/man1/needs-restarting.*
-%exclude %{_mandir}/man1/repo-graph.*
-%exclude %{_mandir}/man1/repoclosure.*
-%exclude %{_mandir}/man1/repomanage.*
-%exclude %{_mandir}/man1/reposync.*
-%exclude %{_mandir}/man1/yum-builddep.*
-%exclude %{_mandir}/man1/yum-config-manager.*
-%exclude %{_mandir}/man1/yum-debug-dump.*
-%exclude %{_mandir}/man1/yum-debug-restore.*
-%exclude %{_mandir}/man1/yumdownloader.*
-%endif
 
 %if %{with python2}
 %files -n python2-%{name} -f %{name}.lang
@@ -538,13 +511,39 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_bindir}/yum-debug-dump
 %{_bindir}/yum-debug-restore
 %{_bindir}/yumdownloader
+%{_mandir}/man8/yum-copr.*
+%{_mandir}/man1/debuginfo-install.*
+%{_mandir}/man1/needs-restarting.*
+%{_mandir}/man1/repo-graph.*
+%{_mandir}/man1/repoclosure.*
+%{_mandir}/man1/repomanage.*
+%{_mandir}/man1/reposync.*
+%{_mandir}/man1/yum-builddep.*
+%{_mandir}/man1/yum-config-manager.*
+%{_mandir}/man1/yum-debug-dump.*
+%{_mandir}/man1/yum-debug-restore.*
+%{_mandir}/man1/yumdownloader.*
 %{_mandir}/man1/package-cleanup.*
+%{_mandir}/man1/dnf-utils.*
+# These are only built with dnfutils bcond.
 %{_mandir}/man1/find-repos-of-install.*
 %{_mandir}/man1/repoquery.*
 %{_mandir}/man1/repotrack.*
-%{_mandir}/man1/dnf-utils.*
 %{_mandir}/man1/yum-utils.*
 %else
+# These are built regardless of dnfutils bcond so we need to exclude them.
+%exclude %{_mandir}/man8/yum-copr.*
+%exclude %{_mandir}/man1/debuginfo-install.*
+%exclude %{_mandir}/man1/needs-restarting.*
+%exclude %{_mandir}/man1/repo-graph.*
+%exclude %{_mandir}/man1/repoclosure.*
+%exclude %{_mandir}/man1/repomanage.*
+%exclude %{_mandir}/man1/reposync.*
+%exclude %{_mandir}/man1/yum-builddep.*
+%exclude %{_mandir}/man1/yum-config-manager.*
+%exclude %{_mandir}/man1/yum-debug-dump.*
+%exclude %{_mandir}/man1/yum-debug-restore.*
+%exclude %{_mandir}/man1/yumdownloader.*
 %exclude %{_mandir}/man1/package-cleanup.*
 %exclude %{_mandir}/man1/dnf-utils.*
 %endif

--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 3.6.1}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 3.7.0}
 %{?!dnf_not_compatible: %global dnf_not_compatible 4.0}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.7.0
@@ -24,7 +24,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        3.0.4
+Version:        3.1
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+
@@ -406,6 +406,11 @@ ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-config-manager
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-debug-dump
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yum-debug-restore
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/yumdownloader
+# These commands don't have a dedicated man page, so let's just point them to
+# dnf-utils(1) which contains the descriptions.
+ln -sf %{_mandir}/man1/dnf-utils.1.gz %{buildroot}%{_mandir}/man1/find-repos-of-install.1.gz
+ln -sf %{_mandir}/man1/dnf-utils.1.gz %{buildroot}%{_mandir}/man1/repoquery.1.gz
+ln -sf %{_mandir}/man1/dnf-utils.1.gz %{buildroot}%{_mandir}/man1/repotrack.1.gz
 ln -sf %{_mandir}/man1/dnf-utils.1.gz %{buildroot}%{_mandir}/man1/yum-utils.1.gz
 %endif
 
@@ -534,6 +539,9 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_bindir}/yum-debug-restore
 %{_bindir}/yumdownloader
 %{_mandir}/man1/package-cleanup.*
+%{_mandir}/man1/find-repos-of-install.*
+%{_mandir}/man1/repoquery.*
+%{_mandir}/man1/repotrack.*
 %{_mandir}/man1/dnf-utils.*
 %{_mandir}/man1/yum-utils.*
 %else

--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -17,12 +17,6 @@
 %bcond_with yumcompatibility
 %endif
 
-%if 0%{?rhel} && 0%{?rhel} <= 7
-%bcond_with dnfutils
-%else
-%bcond_without dnfutils
-%endif
-
 Name:           dnf-plugins-core
 Version:        3.1
 Release:        1%{?dist}
@@ -147,7 +141,7 @@ copr, debug, debuginfo-install, download, needs-restarting, repoclosure, repogra
 reposync commands. Additionally provides generate_completion_cache passive plugin.
 %endif
 
-%if %{with dnfutils}
+%if %{with yumcompatibility}
 %package -n dnf-utils
 Conflicts:      yum-utils < 1.1.31-513
 %if 0%{?rhel} != 7
@@ -381,7 +375,7 @@ pushd build-py3
 popd
 %endif
 %find_lang %{name}
-%if %{with dnfutils}
+%if %{with yumcompatibility}
   %if %{with python3}
   mv %{buildroot}%{_libexecdir}/dnf-utils-3 %{buildroot}%{_libexecdir}/dnf-utils
   %else
@@ -390,7 +384,7 @@ popd
 %endif
 rm -vf %{buildroot}%{_libexecdir}/dnf-utils-*
 
-%if %{with dnfutils}
+%if %{with yumcompatibility}
 mkdir -p %{buildroot}%{_bindir}
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/debuginfo-install
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/find-repos-of-install
@@ -494,7 +488,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{python3_sitelib}/dnfpluginscore/
 %endif
 
-%if %{with dnfutils}
+%if %{with yumcompatibility}
 %files -n dnf-utils
 %{_libexecdir}/dnf-utils
 %{_bindir}/debuginfo-install
@@ -525,13 +519,13 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_mandir}/man1/yumdownloader.*
 %{_mandir}/man1/package-cleanup.*
 %{_mandir}/man1/dnf-utils.*
-# These are only built with dnfutils bcond.
+# These are only built with yumcompatibility.
 %{_mandir}/man1/find-repos-of-install.*
 %{_mandir}/man1/repoquery.*
 %{_mandir}/man1/repotrack.*
 %{_mandir}/man1/yum-utils.*
 %else
-# These are built regardless of dnfutils bcond so we need to exclude them.
+# These are built regardless of yumcompatibility so we need to exclude them.
 %exclude %{_mandir}/man8/yum-copr.*
 %exclude %{_mandir}/man1/debuginfo-install.*
 %exclude %{_mandir}/man1/needs-restarting.*

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -46,6 +46,7 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/debuginfo-install.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-config-manager.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-dump.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-restore.1
+    ${CMAKE_CURRENT_BINARY_DIR}/yumdownloader.1
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-utils.1
 	DESTINATION share/man/man1)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -47,6 +47,7 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/debuginfo-install.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-dump.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-restore.1
     ${CMAKE_CURRENT_BINARY_DIR}/yumdownloader.1
+    ${CMAKE_CURRENT_BINARY_DIR}/package-cleanup.1
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-utils.1
 	DESTINATION share/man/man1)
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -46,6 +46,7 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/debuginfo-install.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-config-manager.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-dump.1
     ${CMAKE_CURRENT_BINARY_DIR}/yum-debug-restore.1
+    ${CMAKE_CURRENT_BINARY_DIR}/dnf-utils.1
 	DESTINATION share/man/man1)
 
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/yum-versionlock.conf.5

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -283,6 +283,7 @@ man_pages = [
      AUTHORS, 1),
     ('debug', 'yum-debug-dump', u'redirecting to DNF debug Plugin', AUTHORS, 1),
     ('debug', 'yum-debug-restore', u'redirecting to DNF debug Plugin', AUTHORS, 1),
+    ('download', 'yumdownloader', u'redirecting to DNF download Plugin', AUTHORS, 1),
     ('dnf-utils', 'dnf-utils', u'classic YUM utilities implemented as CLI shims on top of DNF',
      AUTHORS, 1),
 ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -283,6 +283,8 @@ man_pages = [
      AUTHORS, 1),
     ('debug', 'yum-debug-dump', u'redirecting to DNF debug Plugin', AUTHORS, 1),
     ('debug', 'yum-debug-restore', u'redirecting to DNF debug Plugin', AUTHORS, 1),
+    ('dnf-utils', 'dnf-utils', u'classic YUM utilities implemented as CLI shims on top of DNF',
+     AUTHORS, 1),
 ]
 
 # If true, show URL addresses after external links.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -284,6 +284,8 @@ man_pages = [
     ('debug', 'yum-debug-dump', u'redirecting to DNF debug Plugin', AUTHORS, 1),
     ('debug', 'yum-debug-restore', u'redirecting to DNF debug Plugin', AUTHORS, 1),
     ('download', 'yumdownloader', u'redirecting to DNF download Plugin', AUTHORS, 1),
+    ('package-cleanup', 'package-cleanup', u'clean up locally installed, duplicate, or '
+     'orphaned packages.', AUTHORS, 1),
     ('dnf-utils', 'dnf-utils', u'classic YUM utilities implemented as CLI shims on top of DNF',
      AUTHORS, 1),
 ]

--- a/doc/dnf-utils.rst
+++ b/doc/dnf-utils.rst
@@ -40,6 +40,7 @@ Shell Commands
 ``repotrack``
     Track packages and its dependencies and download them.
     Maps to ``yumdownloader --resolve --alldeps``.
+    See :manpage:`yumdownloader(1)` for details.
 :manpage:`yum-builddep(1)`
     Install whatever is needed to build the given .src.rpm, .nosrc.rpm or .spec
     file.
@@ -54,6 +55,6 @@ Shell Commands
 :manpage:`yum-debug-restore(1)`
     Restores system RPM configuration from a dump file.
     Maps to ``dnf debug-restore``.
-``yumdownloader``
+:manpage:`yumdownloader(1)`
     Download binary or source packages.
     Maps to ``dnf download``.

--- a/doc/dnf-utils.rst
+++ b/doc/dnf-utils.rst
@@ -1,0 +1,59 @@
+=========
+DNF Utils
+=========
+
+The main purpose of these shims is ensuring backward compatibility.
+
+--------------
+Shell Commands
+--------------
+
+:manpage:`debuginfo-install(1)`
+    Install the associated debuginfo packages for a given package
+    specification.
+    Maps to ``dnf debuginfo-install``.
+``find-repos-of-install``
+    Report which repository the package was installed from.
+    Part of core DNF functionality.
+    Maps to ``dnf list --installed``.
+    See `List Command` in :manpage:`dnf(8)` for details.
+``package-cleanup``
+    Clean up locally installed, duplicate, or orphaned packages.
+:manpage:`repo-graph(1)`
+    Output a full package dependency graph in dot format.
+    Maps to ``dnf repograph``.
+:manpage:`repoclosure(1)`
+    Display a list of unresolved dependencies for repositories.
+    Maps to ``dnf repoclosure``.
+:manpage:`repomanage(1)`
+    Manage a directory of rpm packages.
+    Maps to ``dnf repomanage``.
+``repoquery``
+    Searches the available DNF repositories for selected packages and displays
+    the requested information about them.
+    Part of core DNF functionality.
+    Maps to ``dnf repoquery``.
+    See `Repoquery Command` in :manpage:`dnf(8)` for details.
+:manpage:`reposync(1)`
+    Synchronize packages of a remote DNF repository to a local directory.
+    Maps to ``dnf reposync``.
+``repotrack``
+    Track packages and its dependencies and download them.
+    Maps to ``yumdownloader --resolve --alldeps``.
+:manpage:`yum-builddep(1)`
+    Install whatever is needed to build the given .src.rpm, .nosrc.rpm or .spec
+    file.
+    Maps to ``dnf builddep``.
+:manpage:`yum-config-manager(1)`
+    Manage main DNF configuration options, toggle which repositories are
+    enabled or disabled, and add new repositories.
+    Maps to ``dnf config-manager``.
+:manpage:`yum-debug-dump(1)`
+    Writes system RPM configuration to a dump file.
+    Maps to ``dnf debug-dump``.
+:manpage:`yum-debug-restore(1)`
+    Restores system RPM configuration from a dump file.
+    Maps to ``dnf debug-restore``.
+``yumdownloader``
+    Download binary or source packages.
+    Maps to ``dnf download``.

--- a/doc/dnf-utils.rst
+++ b/doc/dnf-utils.rst
@@ -17,7 +17,7 @@ Shell Commands
     Part of core DNF functionality.
     Maps to ``dnf list --installed``.
     See `List Command` in :manpage:`dnf(8)` for details.
-``package-cleanup``
+:manpage:`package-cleanup(1)`
     Clean up locally installed, duplicate, or orphaned packages.
 :manpage:`repo-graph(1)`
     Output a full package dependency graph in dot format.

--- a/doc/package-cleanup.rst
+++ b/doc/package-cleanup.rst
@@ -1,0 +1,68 @@
+..
+  Copyright (C) 2014  Red Hat, Inc.
+
+  This copyrighted material is made available to anyone wishing to use,
+  modify, copy, or redistribute it subject to the terms and conditions of
+  the GNU General Public License v.2, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY expressed or implied, including the implied warranties of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+  Public License for more details.  You should have received a copy of the
+  GNU General Public License along with this program; if not, write to the
+  Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+  source code or documentation are not subject to the GNU General Public
+  License and may only be used or replicated with the express permission of
+  Red Hat, Inc.
+
+===============
+Package Cleanup
+===============
+
+A DNF-based shim imitating the original YUM-based package-cleanup utility.
+
+--------
+Synopsis
+--------
+
+``package-cleanup [options]``
+
+-------
+Options
+-------
+
+``--leaves``
+    List leaf nodes in the local RPM database.
+    Leaf nodes are RPMs that are not relied upon by any other RPM.
+    Maps to ``dnf repoquery --unneeded``.
+
+``--orphans``
+    List installed packages which are not available from currently configured
+    repositories.
+    Maps to ``dnf repoquery --extras``.
+
+``--problems``
+    List dependency problems in the local RPM database.
+    Maps to ``dnf repoquery --unsatisfied``.
+
+``--dupes``
+    Scan for duplicates in the local RPM database.
+    Maps to ``dnf repoquery --duplicates``.
+
+``--cleandupes``
+    Scan for duplicates in the local RPM database and clean out the older
+    versions.
+    Maps to ``dnf remove --duplicates``.
+
+--------
+Examples
+--------
+
+``package-cleanup --problems``
+    List all dependency problems.
+
+``package-cleanup --orphans``
+    List all packages that are not in any DNF repository.
+
+``package-cleanup --cleandupes``
+    Remove all packages that have a duplicate installed.

--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -19,7 +19,7 @@
 DNF reposync Plugin
 ====================
 
-Synchronize packages of a remote Yum repository to a local directory.
+Synchronize packages of a remote DNF repository to a local directory.
 
 --------
 Synopsis

--- a/libexec/dnf-utils.in
+++ b/libexec/dnf-utils.in
@@ -84,22 +84,15 @@ if command == 'package-cleanup':
     elif '--orphans' in args:
         args[args.index('--orphans')] = '--extras'
         MAPPING[command] = ['repoquery']
-    elif '--oldkernels' in args:
-        args[args.index('--oldkernels')] = '--installonly'
-        MAPPING[command] = ['repoquery']
     elif '--problems' in args:
         args[args.index('--problems')] = '--unsatisfied'
         MAPPING[command] = ['repoquery']
     elif '--cleandupes' in args:
         args[args.index('--cleandupes')] = '--duplicates'
         MAPPING[command] = ['remove']
-    elif '--oldkernels' in args:
-        args[args.index('--oldkernels')] = '--oldinstallonly'
-        MAPPING[command] = ['remove']
     else:
         sys.stderr.write('package-cleanup has to be executed with one of the options: --dupes, '
-                         '--leaves, --orphans, --oldkernels, --problems, --cleandupes, '
-                         'or --oldkernels\n')
+                         '--leaves, --orphans, --problems or --cleandupes\n')
         sys.exit(1)
 
 main.user_main(MAPPING[command] + args, exit_code=True)


### PR DESCRIPTION
* Adds missing dnf-utils (yum-utils), yumdownloader and package-cleanup man pages
* Adds man page symlinks for the remaining commands
* Removes incompatible options from package-cleanup