### PR TITLE
Add characters into repo URL sanitization (RhBug:1615416)

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -187,12 +187,12 @@ def save_to_file(filename, content):
 
 # Regular expressions to sanitise cache filenames
 RE_SCHEME = re.compile(r'^\w+:/*(\w+:|www\.)?')
-RE_SLASH = re.compile(r'[?/:&#|~]+')
+RE_SLASH = re.compile(r'[?/:&#|~\*\[\]\(\)\'\\]+')
 RE_BEGIN = re.compile(r'^[,.]*')
 RE_FINAL = re.compile(r'[,.]*$')
 
 def sanitize_url_to_fs(url):
-    """Return a filename suitable for the filesystem
+    """Return a filename suitable for the filesystem and for repo id
 
     Strips dangerous and common characters to create a filename we
     can use to store the cache in.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1615416
This won't fix the bug completely - there is also problem with the * in the baseurl. This issue resolves PR https://github.com/rpm-software-management/libdnf/pull/581