### PR TITLE
Download only packages with unique NEVRAs (RhBug:1612874)

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -119,8 +119,16 @@ class DownloadCommand(dnf.cli.Command):
         """
         Perform the download for a list of packages
         """
-        self.base.download_packages(pkgs, self.base.output.progress)
-        locations = sorted([pkg.localPkg() for pkg in pkgs])
+        pkg_dict = {}
+        for pkg in pkgs:
+            pkg_dict.setdefault(str(pkg), []).append(pkg)
+
+        to_download = []
+        for pkg_list in pkg_dict.values():
+            pkg_list.sort(key=lambda x: (x.repo.priority, x.repo.cost))
+            to_download.append(pkg_list[0])
+        self.base.download_packages(to_download, self.base.output.progress)
+        locations = sorted([pkg.localPkg() for pkg in to_download])
         return locations
 
     def _get_pkg_objs_rpms(self, pkg_specs):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -109,23 +109,23 @@ class QueryStub(object):
         return self.run()[key]
 
 PACKAGES_AVAIL = [
-PkgStub('foo', '0', '1.0', '1', 'noarch', 'test-repo'),
-PkgStub('foo', '0', '2.0', '1', 'noarch', 'test-repo'),
-PkgStub('bar', '0', '1.0', '1', 'noarch', 'test-repo'),
-PkgStub('bar', '0', '2.0', '1', 'noarch', 'test-repo'),
-PkgStub('foobar', '0', '1.0', '1', 'noarch', 'test-repo'),
-PkgStub('foobar', '0', '2.0', '1', 'noarch', 'test-repo'),
-PkgStub('kernel-PAE', '0', '4.0', '1', 'x86_64', 'test-repo'),
-PkgStub('krb5-libs', '0', '1.12', '1', 'x86_64', 'test-repo'),
+PkgStub('foo', '0', '1.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('foo', '0', '2.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('bar', '0', '1.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('bar', '0', '2.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('foobar', '0', '1.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('foobar', '0', '2.0', '1', 'noarch', 'test-repo', repo=mock.Mock()),
+PkgStub('kernel-PAE', '0', '4.0', '1', 'x86_64', 'test-repo', repo=mock.Mock()),
+PkgStub('krb5-libs', '0', '1.12', '1', 'x86_64', 'test-repo', repo=mock.Mock()),
 ]
 
 PACKAGES_DEBUGINFO = [
-PkgStub('foo-debuginfo', '0', '1.0', '1', 'noarch', 'test-repo-debuginfo'),
-PkgStub('foo-debuginfo', '0', '2.0', '1', 'noarch', 'test-repo-debuginfo'),
-PkgStub('bar-debuginfo', '0', '1.0', '1', 'noarch', 'test-repo-debuginfo'),
-PkgStub('bar-debuginfo', '0', '2.0', '1', 'noarch', 'test-repo-debuginfo'),
-PkgStub('kernel-PAE-debuginfo', '0', '4.0', '1', 'x86_64', 'test-repo-debuginfo'),
-PkgStub('krb5-debuginfo', '0', '1.12', '1', 'x86_64', 'test-repo-debuginfo'),
+PkgStub('foo-debuginfo', '0', '1.0', '1', 'noarch', 'test-repo-debuginfo', repo=mock.Mock()),
+PkgStub('foo-debuginfo', '0', '2.0', '1', 'noarch', 'test-repo-debuginfo', repo=mock.Mock()),
+PkgStub('bar-debuginfo', '0', '1.0', '1', 'noarch', 'test-repo-debuginfo', repo=mock.Mock()),
+PkgStub('bar-debuginfo', '0', '2.0', '1', 'noarch', 'test-repo-debuginfo', repo=mock.Mock()),
+PkgStub('kernel-PAE-debuginfo', '0', '4.0', '1', 'x86_64', 'test-repo-debuginfo', repo=mock.Mock()),
+PkgStub('krb5-debuginfo', '0', '1.12', '1', 'x86_64', 'test-repo-debuginfo', repo=mock.Mock()),
 ]
 
 PACKAGES_LASTEST = [
@@ -141,19 +141,19 @@ PACKAGES_DEBUGINFO[5],
 ]
 
 PACKAGES_INST = [
-PkgStub('foo', '0', '1.0', '1', 'noarch', '@System'),
-PkgStub('foobar', '0', '1.0', '1', 'noarch', '@System')
+PkgStub('foo', '0', '1.0', '1', 'noarch', '@System', repo=mock.Mock()),
+PkgStub('foobar', '0', '1.0', '1', 'noarch', '@System', repo=mock.Mock())
 ]
 
 PACKAGES_SOURCE = [
-PkgStub('foo', '0', '1.0', '1', 'src', 'test-repo-source'),
-PkgStub('foo', '0', '2.0', '1', 'src', 'test-repo-source'),
-PkgStub('bar', '0', '1.0', '1', 'src', 'test-repo-source'),
-PkgStub('bar', '0', '2.0', '1', 'src', 'test-repo-source'),
-PkgStub('foobar', '0', '1.0', '1', 'src', 'test-repo-source'),
-PkgStub('foobar', '0', '2.0', '1', 'src', 'test-repo-source'),
-PkgStub('kernel', '0', '4.0', '1', 'src', 'test-repo-source'),
-PkgStub('krb5', '0', '1.12', '1', 'src', 'test-repo-source'),
+PkgStub('foo', '0', '1.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('foo', '0', '2.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('bar', '0', '1.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('bar', '0', '2.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('foobar', '0', '1.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('foobar', '0', '2.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('kernel', '0', '4.0', '1', 'src', 'test-repo-source', repo=mock.Mock()),
+PkgStub('krb5', '0', '1.12', '1', 'src', 'test-repo-source', repo=mock.Mock()),
 ]
 
 


### PR DESCRIPTION
Downloading multiple packages with same NEVRA into same location results
in fail during checksum check. Now only one package with same NEVRA will
be downloaded.

https://bugzilla.redhat.com/show_bug.cgi?id=1612874