### PR TITLE
leaves: ignore multiply satisfied dependencies

### DIFF
--- a/plugins/leaves.py
+++ b/plugins/leaves.py
@@ -57,7 +57,7 @@ class LeavesCommand(dnf.cli.Command):
                     continue
                 for dpkg in query.filter(provides=req):
                     providers.add(pkgmap[dpkg])
-                if i not in providers:
+                if len(providers) == 1 and i not in providers:
                     deps.update(providers)
                 providers.clear()
 


### PR DESCRIPTION
This prevents a situation where package A depends on
Adep, two installed packages B and C provides Adep,
but neither B or C are shown by dnf leaves even though
either B or C (but not both) can be uninstalled
without problems.

The drawback is that the user may look at dnf leaves
and try to 'dnf uninstall B C' and be confused why dnf
also wants to uninstall A.

However, we already have a similar situation when
dnf leaves shows all packages in a strongly connected
component. Eg. git depends on perl-Git and perl-Git depends
on git, so both are shown by dnf leaves when nothing else
depends on git or perl-Git and the user might similarly be
confused why dnf wants to uninstall git when trying to
uninstall perl-Git.