### PR TITLE
versionlock.py: Avoid redundant comments in the lock file

### DIFF
--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -208,11 +208,12 @@ def _write_locklist(base, args, try_installed, comment, info, prefix):
         for pkg in pkgs:
             specs.add(pkgtup2spec(*pkg.pkgtup))
 
-    with open(locklist_fn, 'a') as f:
-        f.write(comment)
-        for spec in specs:
-            logger.info("%s %s", info, spec)
-            f.write("%s%s\n" % (prefix, spec))
+    if specs:
+        with open(locklist_fn, 'a') as f:
+            f.write(comment)
+            for spec in specs:
+                logger.info("%s %s", info, spec)
+                f.write("%s%s\n" % (prefix, spec))
 
 
 def _match(ent, patterns):


### PR DESCRIPTION
Don't write update comments to the lock file ("added lock") when there aren't actually any package references being added.