### PR TITLE
Trim all not allowed characters from repoID (RhBug:1557340)

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -223,5 +223,6 @@ def sanitize_url_to_fs(url):
         csum = dnf.yum.misc.Checksums(['sha256'])
         csum.update(url[lastindex:])
         url = url[:lastindex] + '_' + csum.hexdigest()
-
-    return url
+    # remove all not allowed characters
+    allowed_regex = "[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-]"
+    return re.sub(allowed_regex, '', url)


### PR DESCRIPTION
It fixes config-manager --add-repo created with non-valid repo id.

https://bugzilla.redhat.com/show_bug.cgi?id=1557340