### PR TITLE
Revert "spec: bcond: dnfutils -> yumcompatibility"

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -16,6 +16,12 @@
 %bcond_with yumcompatibility
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} <= 7
+%bcond_with dnfutils
+%else
+%bcond_without dnfutils
+%endif
+
 Name:           dnf-plugins-core
 Version:        4.0.0
 Release:        1%{?dist}
@@ -137,7 +143,7 @@ copr, debug, debuginfo-install, download, needs-restarting, repoclosure, repogra
 reposync commands. Additionally provides generate_completion_cache passive plugin.
 %endif
 
-%if %{with yumcompatibility}
+%if %{with dnfutils}
 %package -n dnf-utils
 Conflicts:      yum-utils < 1.1.31-513
 %if 0%{?rhel} != 7
@@ -369,7 +375,7 @@ pushd build-py3
 popd
 %endif
 %find_lang %{name}
-%if %{with yumcompatibility}
+%if %{with dnfutils}
   %if %{with python3}
   mv %{buildroot}%{_libexecdir}/dnf-utils-3 %{buildroot}%{_libexecdir}/dnf-utils
   %else
@@ -378,7 +384,7 @@ popd
 %endif
 rm -vf %{buildroot}%{_libexecdir}/dnf-utils-*
 
-%if %{with yumcompatibility}
+%if %{with dnfutils}
 mkdir -p %{buildroot}%{_bindir}
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/debuginfo-install
 ln -sf %{_libexecdir}/dnf-utils %{buildroot}%{_bindir}/find-repos-of-install
@@ -482,7 +488,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{python3_sitelib}/dnfpluginscore/
 %endif
 
-%if %{with yumcompatibility}
+%if %{with dnfutils}
 %files -n dnf-utils
 %{_libexecdir}/dnf-utils
 %{_bindir}/debuginfo-install
@@ -513,13 +519,13 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_mandir}/man1/yumdownloader.*
 %{_mandir}/man1/package-cleanup.*
 %{_mandir}/man1/dnf-utils.*
-# These are only built with yumcompatibility.
+# These are only built with dnfutils bcond.
 %{_mandir}/man1/find-repos-of-install.*
 %{_mandir}/man1/repoquery.*
 %{_mandir}/man1/repotrack.*
 %{_mandir}/man1/yum-utils.*
 %else
-# These are built regardless of yumcompatibility so we need to exclude them.
+# These are built regardless of dnfutils bcond so we need to exclude them.
 %exclude %{_mandir}/man8/yum-copr.*
 %exclude %{_mandir}/man1/debuginfo-install.*
 %exclude %{_mandir}/man1/needs-restarting.*


### PR DESCRIPTION
I missed the fact that, for Fedora <= 29, dnf-utils was not built any
more with the original commit.  My mistake.  Let's revert it now as a
quick fix and consider a better fix later.

This reverts commit 9d07c0da599448e963e214ef50160b8b1f164b96.