### PR TITLE
[download] Exclude command line repo from searching package

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -243,7 +243,8 @@ class DownloadCommand(dnf.cli.Command):
         q = q.available()
         q = q.latest()
         if self.opts.arches:
-            q = q.filter(arch=self.opts.arches)
+            q.filterm(arch=self.opts.arches)
+        q.filterm(reponame__neq=hawkey.CMDLINE_REPO_NAME)
         if len(q.run()) == 0:
             msg = _("No package %s available.") % (pkg_spec)
             raise dnf.exceptions.PackageNotFoundError(msg)
@@ -256,8 +257,9 @@ class DownloadCommand(dnf.cli.Command):
         q = self.base.sack.query()
         q = q.available()
         q = q.latest()
-        q = q.filter(name=nevra.name, version=nevra.version,
-                     release=nevra.release, arch=nevra.arch)
+        q.filterm(reponame__neq=hawkey.CMDLINE_REPO_NAME)
+        q.filterm(name=nevra.name, version=nevra.version,
+                  release=nevra.release, arch=nevra.arch)
         if len(q.run()) == 0:
             msg = _("No package %s available.") % (pkg_spec)
             raise dnf.exceptions.PackageNotFoundError(msg)


### PR DESCRIPTION
$ dnf download acpi-1.7-9.fc28.x86_64.rpm
Last metadata expiration check: 0:20:41 ago on Thu 25 Oct 2018 01:27:34 AM EDT.
Traceback (most recent call last):
  File "/usr/bin/dnf", line 98, in <module>
    main.user_main(MAPPING[command] + args, exit_code=True)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 1055, in run
    return self.command.run()
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 116, in run
    self._do_downloads(pkgs)  # download rpms
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 128, in _do_downloads
    pkg_list.sort(key=lambda x: (x.repo.priority, x.repo.cost))
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 128, in <lambda>
    pkg_list.sort(key=lambda x: (x.repo.priority, x.repo.cost))
  File "/usr/lib/python3.6/site-packages/dnf/package.py", line 158, in repo
    return self.base.repos[self.reponame]
KeyError: '@commandline'