### PR TITLE
[download] Fix traceback when local rpm / url is passed

### DIFF
--- a/tests/support.py
+++ b/tests/support.py
@@ -211,6 +211,7 @@ class PkgStub:
         self.release = r
         self.arch = a
         self.epoch = e
+        self.repoid = repo_id
         self.reponame = repo_id
         self.src_name = src_name
         self.repo = repo

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -70,6 +70,10 @@ class QueryStub(object):
         self._filter = kwargs
         return self
 
+    def filterm(self, **kwargs):
+        self._filter = kwargs
+        return self
+
     def _stub_filter(self, **kwargs):
         results = self._all
 
@@ -262,11 +266,7 @@ class DownloadCommandTest(unittest.TestCase):
     def test_get_query_with_local_rpm(self):
         try:
             (fs, rpm_path) = tempfile.mkstemp('foobar-99.99-1.x86_64.rpm')
-            # b/c self.cmd.cli.base.add_remote_rpms is a mock object it
-            # will not update the available packages while testing.
-            # it is expected to hit this exception
-            with self.assertRaises(dnf.exceptions.PackageNotFoundError):
-                self.cmd._get_query(rpm_path)
+            self.cmd._get_query(rpm_path)
             self.cmd.cli.base.add_remote_rpms.assert_called_with([rpm_path], progress=None)
         finally:
             os.remove(rpm_path)


### PR DESCRIPTION
$ dnf download acpi-1.7-9.fc28.x86_64.rpm
Last metadata expiration check: 0:20:41 ago on Thu 25 Oct 2018 01:27:34 AM EDT.
Traceback (most recent call last):
  File "/usr/bin/dnf", line 98, in <module>
    main.user_main(MAPPING[command] + args, exit_code=True)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 179, in user_main
    errcode = main(args)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 64, in main
    return _main(base, args, cli_class, option_parser_class)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 99, in _main
    return cli_run(cli, base)
  File "/usr/lib/python3.6/site-packages/dnf/cli/main.py", line 115, in cli_run
    cli.run()
  File "/usr/lib/python3.6/site-packages/dnf/cli/cli.py", line 1055, in run
    return self.command.run()
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 116, in run
    self._do_downloads(pkgs)  # download rpms
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 128, in _do_downloads
    pkg_list.sort(key=lambda x: (x.repo.priority, x.repo.cost))
  File "/usr/lib/python3.6/site-packages/dnf-plugins/download.py", line 128, in <lambda>
    pkg_list.sort(key=lambda x: (x.repo.priority, x.repo.cost))
  File "/usr/lib/python3.6/site-packages/dnf/package.py", line 158, in repo
    return self.base.repos[self.reponame]
KeyError: '@commandline'