### PR TITLE
doc: Use the correct sphinx-build binary for Python 2 or Python 3

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,11 +1,18 @@
 # html and man documentation are separate targets, apparently there's no way to
 # tell sphinx-build to do them both in one go:
+
+if (${PYTHON_VERSION_MAJOR} STREQUAL "2")
+    SET(SPHINX_BUILD_NAME "sphinx-build")
+else()
+    SET(SPHINX_BUILD_NAME "sphinx-build-3")
+endif()
+
 ADD_CUSTOM_TARGET (doc-html
-		  PYTHONPATH=${CMAKE_SOURCE_DIR} sphinx-build -b html
+		  PYTHONPATH=${CMAKE_SOURCE_DIR} ${SPHINX_BUILD_NAME} -b html
 		  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
 		  COMMENT "Building html documentation")
 ADD_CUSTOM_TARGET (doc-man
-		  PYTHONPATH=${CMAKE_SOURCE_DIR} sphinx-build -b man
+		  PYTHONPATH=${CMAKE_SOURCE_DIR} ${SPHINX_BUILD_NAME} -b man
 		  ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
 		  COMMENT "Building manpage documentation")
 ADD_CUSTOM_TARGET (doc)


### PR DESCRIPTION
When trying to build dnf-plugins-core purely as a Python 3 package, man page generation fails because `sphinx-build` cannot be found, due to `python3-sphinx` not providing that binary.