### PR TITLE
don't assume cli for sack operation in versionlock to honor api load

### DIFF
--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -61,6 +61,8 @@ class VersionLock(dnf.Plugin):
                        and cp.get('main', 'locklist'))
 
     def sack(self):
+        if self.cli == None:
+            pass # loaded via the api, not called by cli
         if not self.cli.demands.resolving:
             logger.debug(NO_VERSIONLOCK)
             return

--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -61,8 +61,8 @@ class VersionLock(dnf.Plugin):
                        and cp.get('main', 'locklist'))
 
     def sack(self):
-        if self.cli == None:
-            pass # loaded via the api, not called by cli
+        if self.cli is None:
+            pass  # loaded via the api, not called by cli
         if not self.cli.demands.resolving:
             logger.debug(NO_VERSIONLOCK)
             return

--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -63,7 +63,7 @@ class VersionLock(dnf.Plugin):
     def sack(self):
         if self.cli is None:
             pass  # loaded via the api, not called by cli
-        if not self.cli.demands.resolving:
+        elif not self.cli.demands.resolving:
             logger.debug(NO_VERSIONLOCK)
             return
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

Previously if you attempted to load this plugin via the python api it would fail because `self.cli` is never instantiated.

```
In [2]: # %load /home/admiller/prep_dnf_transaction.py
   ...: #!/usr/bin/python3
   ...: import dnf
   ...: base = dnf.Base()
   ...: base.conf.read()
   ...: base.read_all_repos()
   ...: base.init_plugins()
   ...: base.pre_configure_plugins()
   ...: base.configure_plugins()
   ...: base.fill_sack()
   ...: base.read_comps()
   ...:
   ...:
   ...:
Failed loading plugin: copr
Failed to synchronize cache for repo 'rcm-tools-fedora-rpms', disabling.
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-2eb170f829f3> in <module>()
      8 base.pre_configure_plugins()
      9 base.configure_plugins()
---> 10 base.fill_sack()
     11 base.read_comps()
     12

/usr/lib/python3.6/site-packages/dnf/base.py in fill_sack(self, load_system_repo, load_available_repos)
    502         timer()
    503         self._goal = dnf.goal.Goal(self._sack)
--> 504         self._plugins.run_sack()
    505         return self._sack
    506

/usr/lib/python3.6/site-packages/dnf/plugin.py in fn(self)
     94     def _caller(method):
     95         def fn(self):
---> 96             dnf.util.mapall(operator.methodcaller(method), self.plugins)
     97         return fn
     98

/usr/lib/python3.6/site-packages/dnf/util.py in mapall(fn, *seq)
    230
    231     """
--> 232     return list(map(fn, *seq))
    233
    234 def normalize_time(timestamp):

/usr/lib/python3.6/site-packages/dnf-plugins/versionlock.py in sack(self)
     59
     60     def sack(self):
---> 61         if not self.cli.demands.resolving:
     62             logger.debug(NO_VERSIONLOCK)
     63             return

AttributeError: 'NoneType' object has no attribute 'demands'
```

