### PR TITLE
Not download src without --source (RhBug:1666648)

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -257,7 +257,7 @@ class DownloadCommand(dnf.cli.Command):
             pkgs = self.base.add_remote_rpms([pkg_spec], progress=self.base.output.progress)
             return self.base.sack.query().filterm(pkg=pkgs)
         subj = dnf.subject.Subject(pkg_spec)
-        q = subj.get_best_query(self.base.sack)
+        q = subj.get_best_query(self.base.sack, with_src=False)
         q = q.available()
         q = q.latest()
         if self.opts.arches:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -173,7 +173,7 @@ class SubjectStub(dnf.subject.Subject):
         super(self.__class__, self).__init__(pkg_spec, ignore_case)
         self.pkg_spec = pkg_spec
 
-    def get_best_query(self, sack, with_provides=True, forms=None):
+    def get_best_query(self, sack, with_provides=True, forms=None, with_src=True):
         Q = QueryStub(PACKAGES_INST, PACKAGES_AVAIL,
                   PACKAGES_LASTEST, PACKAGES_SOURCE,
                   PACKAGES_DEBUGINFO)


### PR DESCRIPTION
"dnf download dnf" will not download src rpm with this patch.

It makes behavior similar with yumdowloader.

https://bugzilla.redhat.com/show_bug.cgi?id=1666648