### PR TITLE
[reposync] Enable timestamp preserving for downloaded data (RhBug:1688537)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,6 +1,6 @@
 %{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.1}
 %global dnf_plugins_extra 2.0.0
-%global hawkey_version 0.7.0
+%global hawkey_version 0.34.0
 
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %bcond_with python3

--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -61,6 +61,9 @@ Options
 ``--metadata-path``
     Root path under which the downloaded metadata are stored. It defaults to ``--download-path`` value if not given.
 
+``--remote-time``
+    Try to set the timestamps of the downloaded files to those on the remote side.
+
 Besides these reposync specific options the ``dnf reposync`` command also accepts all general DNF options. This is especially useful for specifying which repositories should be synchronized (``--repoid`` option). See `Options` in :manpage:`dnf(8)` for details.
 
 --------

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -75,6 +75,9 @@ class RepoSyncCommand(dnf.cli.Command):
                                    'Defaults to the value of --download-path.'))
         parser.add_argument('--source', default=False, action='store_true',
                             help=_('operate on source packages'))
+        parser.add_argument('--remote-time', default=False, action='store_true',
+                            help=_('try to set local timestamps of local files by '
+                                   'the one on the server'))
 
     def configure(self):
         demands = self.cli.demands
@@ -102,6 +105,8 @@ class RepoSyncCommand(dnf.cli.Command):
     def run(self):
         self.base.conf.keepcache = True
         for repo in self.base.repos.iter_enabled():
+            if self.opts.remote_time:
+                repo._repo.setPreserveRemoteTime(True)
             if self.opts.download_metadata:
                 self.download_metadata(repo)
             if self.opts.downloadcomps:


### PR DESCRIPTION
Added new --remote-time command line switch. With this switch on
the reposync command will try to set the timestamps of the downloaded
files to those on the remote side.

https://bugzilla.redhat.com/show_bug.cgi?id=1688537

Requires https://github.com/rpm-software-management/libdnf/pull/725