### PR TITLE
[spec] Postpone yumcompatibility to F31 (RhBug:1707552)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -8,7 +8,7 @@
 %bcond_without python3
 %endif
 
-%if 0%{?rhel} > 7 || 0%{?fedora} > 29
+%if 0%{?rhel} > 7 || 0%{?fedora} > 30
 %bcond_with python2
 %bcond_without yumcompatibility
 %else


### PR DESCRIPTION
We can switch this on after yum package is retired.

https://bugzilla.redhat.com/show_bug.cgi?id=1707552