### PR TITLE
Set the cost of _dnf_local repo to 500, to make it preferred to normal repos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ DNF-PLUGINS-CORE CONTRIBUTORS
     Cyril Jouve <jv.cyril@gmail.com>
     David Michael <fedora.dm0@gmail.com>
     François Rigault <francois.rigault@amadeus.com>
+    Hedayat Vatankhah <hedayat.fwd@gmail.com>
     Jeff Smith <whydoubt@gmail.com>
     Lubomir Rintel <lkundrak@v3.sk>
     Luigi Toscano <luigi.toscano@tiscali.it>

--- a/plugins/local.py
+++ b/plugins/local.py
@@ -103,6 +103,7 @@ class Local(dnf.Plugin):
 
         local_repo = dnf.repo.Repo("_dnf_local", self.base.conf)
         local_repo.baseurl = "file://{}".format(self.main["repodir"])
+        local_repo.cost = 500
         self.base.repos.add(local_repo)
 
     def transaction(self):


### PR DESCRIPTION
Currently, _dnf_local repo is only preferred by name, but it'll not always work; e.g. when a repository name starts with capital letters. 
Instead of relying on alphabetical preference, which (I think) is not even guaranteed, we set its cost to 500 so that it is preferred to normal repositories which has the cost of 1000.
