### PR TITLE
Remove yum-changelog.conf(5) man page (RhBug:1673920)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -449,11 +449,9 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %{_mandir}/man8/dnf.plugin.reposync.*
 %if %{with yumcompatibility}
 %{_mandir}/man1/yum-changelog.*
-%{_mandir}/man5/yum-changelog.conf.*
 %{_mandir}/man8/yum-copr.*
 %else
 %exclude %{_mandir}/man1/yum-changelog.*
-%exclude %{_mandir}/man5/yum-changelog.conf.*
 %exclude %{_mandir}/man8/yum-copr.*
 %endif
 

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -62,7 +62,6 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/debuginfo-install.1
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-utils.1
 	DESTINATION share/man/man1)
 
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/yum-changelog.conf.5
-    ${CMAKE_CURRENT_BINARY_DIR}/yum-versionlock.conf.5
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/yum-versionlock.conf.5
 	DESTINATION share/man/man5)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -284,8 +284,6 @@ man_pages = [
      AUTHORS, 5),
     ('builddep', 'yum-builddep', u'redirecting to DNF builddep Plugin', AUTHORS, 1),
     ('changelog', 'yum-changelog', u'redirecting to DNF changelog Plugin', AUTHORS, 1),
-    ('changelog', 'yum-changelog.conf', u'redirecting to DNF changelog Plugin',
-     AUTHORS, 5),
     ('config_manager', 'yum-config-manager', u'redirecting to DNF config-manager Plugin',
      AUTHORS, 1),
     ('debug', 'yum-debug-dump', u'redirecting to DNF debug Plugin', AUTHORS, 1),


### PR DESCRIPTION
Since this man page is redirected to dnf.plugin.changelog man page
and there is no relevant config file for this plugin remove it.