### PR TITLE
needs-restarting: add --reboothint option

### DIFF
--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -42,3 +42,7 @@ Options
 ``-u, --useronly``
 
     Only consider processes belonging to the running user.
+
+``-r, --reboothint``
+
+    Only report whether a reboot is required (exit code 1) or not (exit code 0).


### PR DESCRIPTION
This is the original implementation from the needs-restarting script in
yum-utils, with a few tweaks (e.g. no versions are printed to keep
things simple).

Original RHEL-7 request:
https://bugzilla.redhat.com/show_bug.cgi?id=1192946

New RHEL-8 request:
https://bugzilla.redhat.com/show_bug.cgi?id=1639468