### PR TITLE
Set skip_if_unavailable=True for plugin local repository

### DIFF
--- a/plugins/local.py
+++ b/plugins/local.py
@@ -103,6 +103,7 @@ class Local(dnf.Plugin):
 
         local_repo = dnf.repo.Repo("_dnf_local", self.base.conf)
         local_repo.baseurl = "file://{}".format(self.main["repodir"])
+        local_repo.skip_if_unavailable = True
         self.base.repos.add(local_repo)
 
     def transaction(self):


### PR DESCRIPTION
It reflects the new default in dnf skip_if_unavailable option. Without
the change, the plugin local will caused to stop working of DNF due to
missing repodata for local plugin repository. The issue is critical for
newly installed machines.