### PR TITLE
Behaviour of "--setopt" in config-manager plugin (RhBug:1702678)

### DIFF
--- a/doc/config_manager.rst
+++ b/doc/config_manager.rst
@@ -19,22 +19,25 @@
  DNF config-manager Plugin
 ==========================
 
-Manage main DNF configuration options, toggle which
+Manage main and repository DNF configuration options, toggle which
 repositories are enabled or disabled, and add new repositories.
 
 --------
 Synopsis
 --------
 
-``dnf config-manager [options] <repoid>...``
+``dnf config-manager [options] <section>...``
 
 ---------
 Arguments
 ---------
 
-``<repoid>``
-    Display / modify a repository identified by <repoid>. If not specified, display / modify
-    main DNF configuration. Repositories can be specified using globs.
+``<section>``
+    This argument can be used to explicitly select the configuration sections to manage.
+    A section can either be ``main`` or a repoid.
+    If not specified, the program will select the ``main`` section and each repoid
+    used within any ``--setopt`` options.
+    A repoid can be specified using globs.
 
 -------
 Options
@@ -51,13 +54,17 @@ Options
     Print dump of current configuration values to stdout.
 
 ``--set-disabled``, ``--disable``
-    Disable the specified repos (automatically saves).
+    Disable the specified repos (implies ``--save``).
 
 ``--set-enabled``, ``--enable``
-    Enable the specified repos (automatically saves).
+    Enable the specified repos (implies ``--save``).
 
 ``--save``
-    Save the current options (useful with --setopt).
+    Save the current options (useful with ``--setopt``).
+
+``--setopt=<option>=<value>``
+    Set a configuration option. To set configuration options for repositories, use
+    ``repoid.option`` for the ``<option>``. Globs are supported in repoid.
 
 --------
 Examples
@@ -71,12 +78,15 @@ Examples
 ``dnf config-manager --dump``
     Display main DNF configuration.
 
-``dnf config-manager <repoid> --dump``
-    Display configuration of a repository identified by <repoid>.
+``dnf config-manager --dump <section>``
+    Display configuration of a repository identified by <section>.
 
 ``dnf config-manager --set-enabled <repoid>``
     Enable repository identified by <repoid> and make the change permanent.
 
-``dnf config-manager --setopt proxy=http://proxy.example.com:3128/ <repo1> <repo2> --save``
+``dnf config-manager --save --setopt=*.proxy=http://proxy.example.com:3128/ <repo1> <repo2>``
     Update proxy setting in repositories with repoid <repo1> and <repo2> and make the change
     permanent.
+
+``dnf config-manager --save --setopt=*-debuginfo.gpgcheck=0``
+    Update gpgcheck setting in all repositories whose id ends with -debuginfo and make the change permanent.

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -90,8 +90,6 @@ class ConfigManagerCommand(dnf.cli.Command):
                 self.base.conf.write_raw_configfile(dnf.const.CONF_FILENAME, 'main', sbc.substitutions, modify)
             if self.opts.dump:
                 print(self.base.output.fmtSection('main'))
-                for name, val in modify.items():
-                    sbc._set_value(name, val)
                 print(self.base.conf.dump())
 
         if self.opts.set_enabled or self.opts.set_disabled:
@@ -120,9 +118,6 @@ class ConfigManagerCommand(dnf.cli.Command):
                 self.base.conf.write_raw_configfile(repo.repofile, repo.id, sbc.substitutions, repo_modify)
             if self.opts.dump:
                 print(self.base.output.fmtSection('repo: ' + repo.id))
-                for name, val in repo_modify.items():
-                    if repo._has_option(name):
-                        repo._set_value(name, val)
                 print(repo.dump())
 
     def add_repo(self):

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -107,7 +107,7 @@ class ConfigManagerCommand(dnf.cli.Command):
             raise dnf.exceptions.Error(_("No matching repo to modify: %s.")
                                        % ', '.join(self.opts.crepo))
         for repo in sorted(matched):
-            repo_modify = dict(modify)  # create local copy
+            repo_modify = {}
             if self.opts.set_enabled:
                 repo_modify['enabled'] = "1"
             elif self.opts.set_disabled:

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -23,6 +23,7 @@ from dnfpluginscore import _, logger, P_
 import dnf
 import dnf.cli
 import dnf.pycomp
+import fnmatch
 import os
 import re
 import shutil
@@ -111,9 +112,10 @@ class ConfigManagerCommand(dnf.cli.Command):
                 repo_modify['enabled'] = "1"
             elif self.opts.set_disabled:
                 repo_modify['enabled'] = "0"
-            if (hasattr(self.opts, 'repo_setopts')
-                    and repo.id in self.opts.repo_setopts):
-                repo_modify.update(self.opts.repo_setopts[repo.id])
+            if hasattr(self.opts, 'repo_setopts'):
+                for repoid, setopts in self.opts.repo_setopts.items():
+                    if fnmatch.fnmatch(repo.id, repoid):
+                        repo_modify.update(setopts)
             if self.opts.save and repo_modify:
                 self.base.conf.write_raw_configfile(repo.repofile, repo.id, sbc.substitutions, repo_modify)
             if self.opts.dump:

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -96,12 +96,16 @@ class ConfigManagerCommand(dnf.cli.Command):
         if self.opts.set_enabled or self.opts.set_disabled:
             self.opts.save = True
 
+        matched = []
         if self.opts.crepo:
-            matched = []
             for name in self.opts.crepo:
                 matched.extend(self.base.repos.get_matching(name))
         else:
-            return
+            if hasattr(self.opts, 'repo_setopts'):
+                for name in self.opts.repo_setopts.keys():
+                    matched.extend(self.base.repos.get_matching(name))
+            if not matched:
+                return
 
         if not matched:
             raise dnf.exceptions.Error(_("No matching repo to modify: %s.")


### PR DESCRIPTION
The PR changes behaviour of `--setopt` in config-manager plugin.

`--setopt:` Fix crash with `--save --dump` 
Adds globs support to `--setopt repoid` (`--setopt=*-debuginfo.key=value`).
` --setopt=key=value` is not applied to repositories config
`--setopt` and empty list of repositories (RhBug:1702678)
`--setopt`: Add check for existence of input repositories

Solves: https://bugzilla.redhat.com/show_bug.cgi?id=1702678
It is more compatible with YUM now.