### PR TITLE
[spec] Add conflict with yum-plugin-copr

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -166,7 +166,8 @@ Additionally provides generate_completion_cache passive plugin.
 %if %{with yumutils}
 %package -n %{yum_utils_subpackage_name}
 %if "%{yum_utils_subpackage_name}" == "dnf-utils"
-Conflicts:      yum-utils < 1.1.31-513
+Conflicts:      yum-utils < 1.1.31-520
+Conflicts:      yum-plugin-copr < 1.1.31-520
 %if 0%{?rhel} != 7
 Provides:       yum-utils = %{version}-%{release}
 %endif


### PR DESCRIPTION
It is required because both provide a same file.

file /usr/share/man/man8/yum-copr.8.gz from install
of yum-plugin-copr-1.1.31-519.fc30.noarch conflicts with file
from package dnf-utils-4.0.7-1.fc30.noarch