### PR TITLE
[spec] Don't rename dnf-utils -> yum-utils on F31

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -2,6 +2,9 @@
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.34.0
 %global yum_utils_subpackage_name dnf-utils
+%if 0%{?rhel} > 7
+%global yum_utils_subpackage_name yum-utils
+%endif
 
 %if 0%{?rhel} && 0%{?rhel} <= 7
 %bcond_with python3
@@ -16,7 +19,6 @@
 %endif
 
 %if 0%{?rhel} > 7 || 0%{?fedora} > 30
-%global yum_utils_subpackage_name yum-utils
 %bcond_without yumcompatibility
 %else
 %bcond_with yumcompatibility


### PR DESCRIPTION
Such a rename would be a risky move that could break something in the
infrastructure so let's leave the dnf-utils name on Fedora.