### PR TITLE
download: add the --debugsource option

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.8}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.10}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.34.0
 %global yum_utils_subpackage_name dnf-utils


### PR DESCRIPTION
Adds the --debugsource option next to the --debuginfo one to support
downloading the *-debugsource packages.

Also changes the behavior to support more than one of [--source,
--debuginfo, --debugsource] options at the same time and downloads all
of the requested packages.

https://bugzilla.redhat.com/show_bug.cgi?id=1637008

tests PR: https://github.com/rpm-software-management/ci-dnf-stack/pull/592