### PR TITLE
[spec] Revert conflict on yum-plugins-copr

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -169,7 +169,6 @@ Additionally provides generate_completion_cache passive plugin.
 %package -n %{yum_utils_subpackage_name}
 %if "%{yum_utils_subpackage_name}" == "dnf-utils"
 Conflicts:      yum-utils < 1.1.31-520
-Conflicts:      yum-plugin-copr < 1.1.31-520
 %if 0%{?rhel} != 7
 Provides:       yum-utils = %{version}-%{release}
 %endif


### PR DESCRIPTION
It turns out this conflict is no longer needed thanks to commit acd13c91
which postponed yumcompatibility (and thus the compat man pages) to
Fedora 31. (Moreover, the conflict should have been under the
dnf-plugins-core package where the man page is shipped, as opposed to
dnf-utils).

Note that the conflict itself doesn't hurt anything but we should keep
things easy to understand.
