### PR TITLE
copr: fixup listing copr repos with separate directory

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -296,11 +296,11 @@ Do you really want to enable {0}?""".format('/'.join([self.copr_hostname,
             return
 
         old_repo = False
-        # repo ID has copr:<hub>:<user>:<project> format
+        # repo ID has copr:<hostname>:<user>:<copr_dir> format, while <copr_dir>
+        # can contain more colons
         if re.match("copr:", repo_id):
-            copr_name = repo_id.rsplit(':', 2)
-            copr_hostname = copr_name[0].split(':', 1)[1]
-            msg = copr_hostname + '/' + copr_name[1] + '/' + copr_name[2]
+            _, copr_hostname, copr_owner, copr_dir = repo_id.split(':', 3)
+            msg = copr_hostname + '/' + copr_owner + "/" + copr_dir
         # repo ID has <user>-<project> format, try to get hub from file name
         elif re.match("_copr:", file_name):
             copr_name = repo_id.split('-', 1)


### PR DESCRIPTION
There's concept of "directories" (copr dirs) in copr, so each project
can have multiple directories (not only the main one).  For example in
some project (say @copr/copr-dev) there's always the main directory;
that is identified by the copr name itself (e.g. '@copr/copr-dev').  But
there might be other directories which are identified by additional
SUFFIX (e.g. '@copr/copr-dev:SUFFIX', typically '@copr/copr-dev:pr:22')

So there might be additional colon(s) in repoID we didn't expect before,
so the 'dnf copr list' was malformed.  See the difference in 'dnf copr
list' output, before/after this fix:

  - copr.fedorainfracloud.org:group_copr:copr-dev/pr/788 (disabled)
  + copr.fedorainfracloud.org/group_copr/copr-dev:pr:788 (disabled)

The previous format of the string was invalid, and user wasn't able to
disable/remove the repo using that string.