### PR TITLE
[doc] Skip creating and installing migrate documentation for Python 3+

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -27,7 +27,6 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-builddep.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-download.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-generate_completion_cache.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-leaves.8
-    ${CMAKE_CURRENT_BINARY_DIR}/dnf-migrate.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-needs-restarting.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-repoclosure.8
     ${CMAKE_CURRENT_BINARY_DIR}/dnf-repodiff.8
@@ -40,6 +39,10 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-builddep.8
     ${CMAKE_CURRENT_BINARY_DIR}/yum-copr.8
     ${CMAKE_CURRENT_BINARY_DIR}/yum-versionlock.8
 	DESTINATION share/man/man8)
+if (${PYTHON_VERSION_MAJOR} STREQUAL "2")
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-migrate.8
+        DESTINATION share/man/man8)
+endif()
 
 if (${WITHOUT_LOCAL} STREQUAL "0")
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/dnf-local.8

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -80,6 +80,8 @@ release = '%s-1' % version
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build']
+if sys.version_info[0] > 2:
+    exclude_patterns.append('migrate.rst')
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -251,7 +253,6 @@ man_pages = [
         u'DNF generate_completion_cache Plugin', AUTHORS, 8),
     ('leaves', 'dnf-leaves', u'DNF leaves Plugin', AUTHORS, 8),
     ('local', 'dnf-local', u'DNF local Plugin', AUTHORS, 8),
-    ('migrate', 'dnf-migrate', u'DNF migrate Plugin', AUTHORS, 8),
     ('needs_restarting', 'dnf-needs-restarting', u'DNF needs_restarting Plugin', AUTHORS, 8),
     ('repoclosure', 'dnf-repoclosure', u'DNF repoclosure Plugin', AUTHORS, 8),
     ('repodiff', 'dnf-repodiff', u'DNF repodiff Plugin', AUTHORS, 8),
@@ -292,6 +293,8 @@ man_pages = [
     ('dnf-utils', 'yum-utils', u'classic YUM utilities implemented as CLI shims on top of DNF',
      AUTHORS, 1),
 ]
+if sys.version_info[0] < 3:
+    man_pages.append(('migrate', 'dnf-migrate', u'DNF migrate Plugin', AUTHORS, 8))
 
 # If true, show URL addresses after external links.
 #man_show_urls = False


### PR DESCRIPTION
The migrate plugin is Python-2-only, and so should be its documentation.

Note: this will not remove references in other files (really just index.rst). Doing so would be non-trivial and is probably not worth the effort. A broken link should be red flag enough for users not to try to use a plugin. Certainly better than shipping documentation for something that won't be available anyway IMHO.