### PR TITLE
[spec] Specify attributes for ghost file (RhBug: 1754463)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -472,7 +472,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %files -n python2-%{name} -f %{name}.lang
 %license COPYING
 %doc AUTHORS README.rst
-%ghost %{_var}/cache/dnf/packages.db
+%ghost %attr(644,-,-) %{_var}/cache/dnf/packages.db
 %config(noreplace) %{_sysconfdir}/dnf/plugins/copr.conf
 %config(noreplace) %{_sysconfdir}/dnf/plugins/copr.d
 %config(noreplace) %{_sysconfdir}/dnf/plugins/debuginfo-install.conf
@@ -497,7 +497,7 @@ PYTHONPATH=./plugins nosetests-%{python3_version} -s tests/
 %files -n python3-%{name} -f %{name}.lang
 %license COPYING
 %doc AUTHORS README.rst
-%ghost %{_var}/cache/dnf/packages.db
+%ghost %attr(644,-,-) %{_var}/cache/dnf/packages.db
 %config(noreplace) %{_sysconfdir}/dnf/plugins/copr.conf
 %config(noreplace) %{_sysconfdir}/dnf/plugins/copr.d
 %config(noreplace) %{_sysconfdir}/dnf/plugins/debuginfo-install.conf


### PR DESCRIPTION
Otherwise "rpm --verify python3-dnf-plugins-core" is complaining:

$ rpm --verify python3-dnf-plugins-core
.M.......  g /var/cache/dnf/packages.db

https://bugzilla.redhat.com/show_bug.cgi?id=1754463