### PR TITLE
[versionlock] Add --raw option (RhBug:1645564)

### DIFF
--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -117,6 +117,13 @@ Options
 
 All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for details.
 
+``--raw``
+    Do not resolve ``<package-name-spec>`` to NEVRAs to find specific version to lock to. Instead ``<package-name-spec>`` are used as they are. This enables locking to not yet available versions of the package.
+    For example you may want to keep the `bash` package on major version 5 and consume any future updates as far as they keep the major version::
+
+        $ dnf versionlock add --raw 'bash-5.*'
+        Adding versionlock on: bash-5.*
+
 -------------
 Configuration
 -------------

--- a/doc/versionlock.rst
+++ b/doc/versionlock.rst
@@ -51,31 +51,61 @@ operations like `repoquery`, `list`, `info`, etc.
 Synopsis
 --------
 
-``dnf versionlock [add|exclude|list|delete|clear] [<package-spec>]``
+``dnf versionlock [options] [add|exclude|list|delete|clear] [<package-name-spec>]``
 
 ---------
 Arguments
 ---------
 
-``<package-spec>``
+``<package-name-spec>``
     Package spec to lock or exclude.
 
 -----------
 Subcommands
 -----------
 
-``dnf versionlock add <package-spec>``
+``dnf versionlock add <package-name-spec>``
     Add a versionlock for all available packages matching the spec. It means that only versions of
-    packages represented by <package-spec> will be available for transaction operations.
+    packages represented by ``<package-name-spec>`` will be available for transaction operations.
+    Each ``<package-name-spec>`` is converted to concrete NEVRAs which are used for locking. The NEVRAs to lock to are first searched among installed packages and then (if none is found) in all currently available packages.
 
-``dnf versionlock exclude <package-spec>``
+    Examples::
+
+        Locking a package to the version installed:
+
+            $ dnf repoquery --installed bash
+            bash-0:5.0.7-1.fc30.x86_64
+
+            $ dnf repoquery bash
+            bash-0:5.0.2-1.fc30.i686
+            bash-0:5.0.2-1.fc30.x86_64
+            bash-0:5.0.7-1.fc30.i686
+            bash-0:5.0.7-1.fc30.x86_64
+
+            $ dnf versionlock add bash
+            Adding versionlock on: bash-0:5.0.7-1.fc30.*
+
+        Locking not installed package to any of available versions:
+
+            $ dnf repoquery --installed mutt
+
+            $ dnf repoquery mutt
+            mutt-5:1.11.4-1.fc30.x86_64
+            mutt-5:1.12.1-3.fc30.x86_64
+
+            $ dnf versionlock add mutt
+            Adding versionlock on: mutt-5:1.11.4-1.fc30.*
+            Adding versionlock on: mutt-5:1.12.1-3.fc30.*
+
+
+``dnf versionlock exclude <package-name-spec>``
     Add an exclude (within  versionlock) for the available packages matching the spec. It means that
-    packages represented by <package-spec> will be excluded from transaction operations.
+    packages represented by ``<package-name-spec>`` will be excluded from transaction operations.
 
 ``dnf versionlock list`` or ``dnf versionlock``
     List the current versionlock entries.
 
-``dnf versionlock delete <package-spec>``
+``dnf versionlock delete <package-name-spec>``
     Remove any matching versionlock entries.
 
 ``dnf versionlock clear``
@@ -102,7 +132,7 @@ The minimal content of conf file should contain ``main`` sections with ``enabled
       information in it. Note that the file has to exist (or the versionlock plugin
       will make dnf exit). However, it can be empty.
 
-      The file takes entries in the format of ``package-spec`` (optionally prefixed with '!' for
+      The file takes entries in the format of ``<package-name-spec>`` (optionally prefixed with '!' for
       excludes).
       See `Specifying packages` in :manpage:`dnf(8)` for details.
 

--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -217,8 +217,12 @@ def _write_locklist(base, args, try_installed, comment, info, prefix):
 
 
 def _match(ent, patterns):
+    ent = ent.lstrip('!')
+    for pat in patterns:
+        if ent == pat:
+            return True
     try:
-        n = hawkey.split_nevra(ent.lstrip('!'))
+        n = hawkey.split_nevra(ent)
     except hawkey.ValueException:
         return False
     for name in (


### PR DESCRIPTION
Versionlock add/exclude commands are now able to insert into
versionlock.list file patterns without converting it into NEVRAs. It is
usable for example for locking package to versions not available yet:

$ dnf version lock --raw add 'bash-5.*'
Adding versionlock on: bash-5.*

This command will keep the bash package on major version 5 and dnf will
still consume any future updates as far as they do not bump the major
version.

Without --raw switch used, the versionlock would take only currently
available packages into account:

$ dnf versionlock add 'bash-5.*'
Adding versionlock on: bash-0:5.0.7-1.fc30.*

https://bugzilla.redhat.com/show_bug.cgi?id=1645564