### PR TITLE
[versionlock] Don't apply excludes on @System (RhBug:1726712)

### DIFF
--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -105,6 +105,7 @@ class VersionLock(dnf.Plugin):
             other_versions = all_versions.difference(locked_query)
             excludes_query = excludes_query.union(other_versions)
 
+        excludes_query.filterm(reponame__neq=hawkey.SYSTEM_REPO_NAME)
         if excludes_query:
             self.base.sack.add_excludes(excludes_query)
 


### PR DESCRIPTION
When you move locked version of the package in versionlock.list config
file to newer version, you should be able to upgrade the package to this version.

https://bugzilla.redhat.com/show_bug.cgi?id=1726712

The test: https://github.com/rpm-software-management/ci-dnf-stack/pull/678