### PR TITLE
[reposync] Apply only modular excludes (RhBug:1750273)

### DIFF
--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -204,7 +204,7 @@ class RepoSyncCommand(dnf.cli.Command):
         return True
 
     def get_pkglist(self, repo):
-        query = self.base.sack.query(flags=hawkey.IGNORE_EXCLUDES).available().filterm(
+        query = self.base.sack.query(flags=hawkey.IGNORE_MODULAR_EXCLUDES).available().filterm(
             reponame=repo.id)
         if self.opts.newest_only:
             query = query.latest()
@@ -219,7 +219,7 @@ class RepoSyncCommand(dnf.cli.Command):
         progress = base.output.progress
         if progress is None:
             progress = dnf.callback.NullDownloadProgress()
-        drpm = dnf.drpm.DeltaInfo(base.sack.query(flags=hawkey.IGNORE_EXCLUDES).installed(),
+        drpm = dnf.drpm.DeltaInfo(base.sack.query(flags=hawkey.IGNORE_MODULAR_EXCLUDES).installed(),
                                   progress, 0)
         payloads = [RPMPayloadLocation(pkg, progress, self.pkg_download_path(pkg))
                     for pkg in pkglist]


### PR DESCRIPTION
This is a regression, reposync always used to apply excludes and
includes. It only needs to ignore modular dependencies to be able to
synchronize non-enabled streams.

https://bugzilla.redhat.com/show_bug.cgi?id=1750273