### PR TITLE
[versionlock] Use demands.plugin_filtering_enabled

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.14}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.16}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.35.7
 %global yum_utils_subpackage_name dnf-utils
@@ -31,7 +31,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        4.0.11
+Version:        4.0.12
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+

--- a/plugins/versionlock.py
+++ b/plugins/versionlock.py
@@ -60,10 +60,17 @@ class VersionLock(dnf.Plugin):
         locklist_fn = (cp.has_section('main') and cp.has_option('main', 'locklist')
                        and cp.get('main', 'locklist'))
 
-    def sack(self):
+    def locking_enabled(self):
         if self.cli is None:
-            pass  # loaded via the api, not called by cli
-        elif not self.cli.demands.resolving:
+            enabled = True  # loaded via the api, not called by cli
+        else:
+            enabled = self.cli.demands.plugin_filtering_enabled
+            if enabled is None:
+                enabled = self.cli.demands.resolving
+        return enabled
+
+    def sack(self):
+        if not self.locking_enabled():
             logger.debug(NO_VERSIONLOCK)
             return
 


### PR DESCRIPTION
The original demands.resolving is used as a fall back if the
plugin_filtering_enabled is not set.

Requires: https://github.com/rpm-software-management/dnf/pull/1530
For testing you can use the copr repo: https://copr.fedorainfracloud.org/coprs/mblaha/versionlockdemand/