### PR TITLE
[builddep] Accept --skip-broken switch (RhBug:1628634)

### DIFF
--- a/doc/builddep.rst
+++ b/doc/builddep.rst
@@ -39,6 +39,11 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
 ``--srpm``
     Treat arguments as source rpm files.
 
+``--skip-unavailable``
+    Skip build dependencies not available in repositories. All available build dependencies will be installed.
+
+Note that `builddep` command does not honor the `--skip-broken` option, so there is no way to skip uninstallable packages (e.g. with broken dependencies).
+
 --------
 Examples
 --------

--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -59,6 +59,8 @@ class BuildDepCommand(dnf.cli.Command):
         parser.add_argument('-D', '--define', action='append', default=[],
                             metavar="'MACRO EXPR'", type=macro_def,
                             help=_('define a macro for spec file parsing'))
+        parser.add_argument('--skip-unavailable', action='store_true', default=False,
+                            help=_('skip build dependencies not available in repositories'))
         ptype = parser.add_mutually_exclusive_group()
         ptype.add_argument('--spec', action='store_true',
                             help=_('treat commandline arguments as spec files'))
@@ -137,7 +139,7 @@ class BuildDepCommand(dnf.cli.Command):
             # Richdeps can have no matches but it could be correct (solver must decide later)
             msg = _("No matching package to install: '%s'")
             logger.warning(msg, reldep_str)
-            return False
+            return self.opts.skip_unavailable is True
 
         if found:
             already_inst = self.base._sltr_matches_installed(sltr)


### PR DESCRIPTION
Using --skip-broken makes builddep command tollerant to uninstallable
packages. All other (installable) build dependencies are going to be
installed.

https://bugzilla.redhat.com/show_bug.cgi?id=1628634

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/689