### PR TITLE
Bump required dnf version

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.16}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.17}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.37.0
 %global yum_utils_subpackage_name dnf-utils


### PR DESCRIPTION
The version bump from the PR
https://github.com/rpm-software-management/dnf/pull/1530 was not
applied.