### PR TITLE
Fix: config_manager respect config file location during save

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -114,8 +114,9 @@ class ConfigManagerCommand(dnf.cli.Command):
                 print("%s = %s" % (name, val))
         if not self.opts.crepo or 'main' in self.opts.crepo:
             if self.opts.save and modify:
-                # modify [main] in dnf.conf
-                self.base.conf.write_raw_configfile(dnf.const.CONF_FILENAME, 'main', sbc.substitutions, modify)
+                # modify [main] in global configuration file
+                self.base.conf.write_raw_configfile(self.base.conf.config_file_path, 'main',
+                                                    sbc.substitutions, modify)
             if self.opts.dump:
                 print(self.base.output.fmtSection('main'))
                 print(self.base.conf.dump())


### PR DESCRIPTION
DNF has the `--config` argument. It defines path to the configuration
file. The config_manager plugin used the configuration from the path
but the changes were allways saved into /etc/dnf/dnf.conf.
The PR fixes it. The changes are saved to the original
configuration file.