### PR TITLE
[config-manager] Allow use of --set-enabled without arguments (RhBug:…

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -67,11 +67,6 @@ class ConfigManagerCommand(dnf.cli.Command):
 
     def run(self):
         """Execute the util action here."""
-
-        if self.opts.set_enabled and not self.opts.crepo:
-            logger.error(_("Error: Trying to enable already enabled repos."))
-            self.opts.set_enabled = False
-
         if self.opts.add_repo:
             self.add_repo()
         else:


### PR DESCRIPTION
…1679213)

Since config-manager was enhanced to also modify repositories specified
by repoids in the --setopt option, it should no longer be required to
specify repoids as arguments for --set-enabled.

As a consequence, "config-manager --set-enabled" without any other
argument will exit with 0 and have no effect (same as "--set-disabled").

https://bugzilla.redhat.com/show_bug.cgi?id=1679213