### PR TITLE
config-manager calls parser error when without options (RhBug:1782822)

### DIFF
--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -61,16 +61,15 @@ class ConfigManagerCommand(dnf.cli.Command):
         demands.available_repos = True
 
         # if no argument was passed then error
-        if (not (self.opts.crepo != [] or
-                 self.opts.add_repo != [] or
+        if (not (self.opts.add_repo != [] or
                  self.opts.save or
                  self.opts.dump or
                  self.opts.dump_variables or
                  self.opts.set_disabled or
                  self.opts.set_enabled) ):
-            self.cli.optparser.error(_("one of the arguments {} is required")
+            self.cli.optparser.error(_("one of the following arguments is required: {}")
                                      .format(' '.join([
-                                         "repo", "--save", "--add-repo",
+                                         "--save", "--add-repo",
                                          "--dump", "--dump-variables",
                                          "--enable", "--disable"])))
 

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -60,6 +60,20 @@ class ConfigManagerCommand(dnf.cli.Command):
         demands = self.cli.demands
         demands.available_repos = True
 
+        # if no argument was passed then error
+        if (not (self.opts.crepo != [] or
+                 self.opts.add_repo != [] or
+                 self.opts.save or
+                 self.opts.dump or
+                 self.opts.dump_variables or
+                 self.opts.set_disabled or
+                 self.opts.set_enabled) ):
+            self.cli.optparser.error(_("one of the arguments {} is required")
+                                     .format(' '.join([
+                                         "repo", "--save", "--add-repo",
+                                         "--dump", "--dump-variables",
+                                         "--enable", "--disable"])))
+
         if (self.opts.save or self.opts.set_enabled or
                 self.opts.set_disabled or self.opts.add_repo):
             demands.root_user = True


### PR DESCRIPTION
The arguments are checked directly inside configure.
Parser error called explicitly
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1782822