### PR TITLE
Add modular support to repomanage (RhBug:1804720)

### DIFF
--- a/doc/repomanage.rst
+++ b/doc/repomanage.rst
@@ -19,7 +19,7 @@
 DNF repomanage Plugin
 =====================
 
-Manage a directory of rpm packages.
+Manage a repository or a simple directory of rpm packages.
 
 --------
 Synopsis
@@ -31,7 +31,9 @@ Synopsis
 Description
 -----------
 
-`repomanage` prints newest or oldest packages in specified directory for easy piping to xargs or similar programs.
+`repomanage` prints newest or oldest packages in a repository specified by <path> for easy piping to xargs or similar programs. In case <path> doesn't contain a valid repository it is searched for rpm packages which are then used instead.
+
+In order to work correctly with modular packages <path> has to contain repodata with modular metadata. If modular content is present `repomanage` prints packages from newest or oldest versions of each stream in addition to newest or oldest non-modular packages.
 
 
 Options
@@ -60,14 +62,14 @@ The following options control how packages are displayed in the output:
 Examples
 --------
 
-Display newest packages in current directory::
+Display newest packages in current repository (directory)::
 
     dnf repomanage --new .
 
-Display 2 newest packages in requires "home" directory::
+Display 2 newest versions of each package in "home" directory::
 
     dnf repomanage --new --keep 2 ~/
 
-Display older package separated by space in current directory::
+Display oldest packages separated by space in current repository (directory)::
 
     dnf repomanage --old --space .

--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -62,7 +62,7 @@ class RepoManageCommand(dnf.cli.Command):
         verfile = {}
         pkgdict = {}
 
-        keepnum = int(self.opts.keep) * (-1)  # the number of items to keep
+        keepnum = int(self.opts.keep) # the number of items to keep
 
         if len(rpm_list) == 0:
             raise dnf.exceptions.Error(_("No files to process"))
@@ -94,10 +94,10 @@ class RepoManageCommand(dnf.cli.Command):
             for (n, a) in pkgdict.keys():
                 evrlist = pkgdict[(n, a)]
 
-                if len(evrlist) < abs(keepnum):
+                if len(evrlist) < keepnum:
                     newevrs = evrlist
                 else:
-                    newevrs = evrlist[keepnum:]
+                    newevrs = evrlist[-keepnum:]
 
                 for package in newevrs:
                     nevra = self._package_to_nevra(package)
@@ -108,10 +108,10 @@ class RepoManageCommand(dnf.cli.Command):
             for (n, a) in pkgdict.keys():
                 evrlist = pkgdict[(n, a)]
 
-                if len(evrlist) < abs(keepnum):
+                if len(evrlist) < keepnum:
                     continue
 
-                oldevrs = evrlist[:keepnum]
+                oldevrs = evrlist[:-keepnum]
                 for package in oldevrs:
                     nevra = self._package_to_nevra(package)
                     for fpkg in verfile[nevra]:

--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -100,7 +100,8 @@ class RepoManageCommand(dnf.cli.Command):
         for pkg in packages:
             na = (pkg.name, pkg.arch)
             if na in pkgdict:
-                pkgdict[na].append(pkg)
+                if pkg not in pkgdict[na]:
+                    pkgdict[na].append(pkg)
             else:
                 pkgdict[na] = [pkg]
 

--- a/tests/support.py
+++ b/tests/support.py
@@ -62,6 +62,17 @@ class BaseStub(object):
             pkgs.append(self.sack.add_cmdline_package(path))
         return pkgs
 
+    def _add_repo_to_sack(self, repo):
+        raise dnf.exceptions.RepoError()
+
+    def reset(self, sack=True, repos=True):
+        self.sack = dnf.sack.Sack()
+        self.repos = dnf.repodict.RepoDict()
+        self.conf = FakeConf()
+
+    def fill_sack(self, load_system_repo=False, load_available_repos=False):
+        return
+
 
 class BaseCliStub(object):
     """A class mocking `dnf.cli.cli.BaseCli`."""


### PR DESCRIPTION
In order to support modular content we have to load repodata with
repodata/modules.yaml present.
If repodata are not present in the target path there is no way to tell
which packages belong to which stream and repomanage will continue to
show packages from different streams as obsoleting each other.

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/825

https://bugzilla.redhat.com/show_bug.cgi?id=1804720