### PR TITLE
Move args --set-enabled/--set-disabled, add messages (RhBug:1727882)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.17}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.22}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.46.1
 %global yum_utils_subpackage_name dnf-utils
@@ -31,7 +31,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        4.0.15
+Version:        4.0.16
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -81,6 +81,11 @@ class ConfigManagerCommand(dnf.cli.Command):
                                          "--set-enabled", "--enable",
                                          "--set-disabled", "--disable"])))
 
+        # warn with hint if --enablerepo or --disablerepo argument was passed
+        if self.opts.repos_ed != []:
+            logger.warning(_("Warning: --enablerepo/--disablerepo arguments have no meaning"
+                             "with config manager. Use --set-enabled/--set-disabled instead."))
+
         if (self.opts.save or self.opts.set_enabled or
                 self.opts.set_disabled or self.opts.add_repo):
             demands.root_user = True

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -78,7 +78,8 @@ class ConfigManagerCommand(dnf.cli.Command):
                                      .format(' '.join([
                                          "--save", "--add-repo",
                                          "--dump", "--dump-variables",
-                                         "--enable", "--disable"])))
+                                         "--set-enabled", "--enable",
+                                         "--set-disabled", "--disable"])))
 
         if (self.opts.save or self.opts.set_enabled or
                 self.opts.set_disabled or self.opts.add_repo):

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -54,6 +54,13 @@ class ConfigManagerCommand(dnf.cli.Command):
         parser.add_argument(
             '--dump-variables', default=False, action='store_true',
             help=_('print variable values to stdout'))
+        enable_group = parser.add_mutually_exclusive_group()
+        enable_group.add_argument("--set-enabled", default=False,
+                                  dest="set_enabled", action="store_true",
+                                  help=_("enable repos (automatically saves)"))
+        enable_group.add_argument("--set-disabled", default=False,
+                                  dest="set_disabled", action="store_true",
+                                  help=_("disable repos (automatically saves)"))
 
     def configure(self):
         # setup sack and populate it with enabled repos


### PR DESCRIPTION
The arguments `--set-enabled`, `--set-disabled` are valid for `config-manager` plugin. 
The fix moves they from general DNF arguments into the plugin arguments.
Note:
There are another "config-manager" arguments `--enable` and `--disable` in the DNF general section. They cannot be moved into config-manager plugin because of Python argparser abbreviation.

Added warning when `--enablerepo`/`--disablerepo` arguments were passed. These global DNF arguments have no meaning with confim-manager plugin. Users are confused and use them instead of --set-enabled/--set-disabled. But it does not work.

Depends on: https://github.com/rpm-software-management/dnf/pull/1621
