### PR TITLE
debug-restore enhancement

### DIFF
--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -23,7 +23,18 @@ DNF debug Plugin
 Description
 -----------
 
-Writes system RPM configuration to a dump file and restore it.
+The plugin provides two dnf commands:
+
+``debug-dump``
+    Writes system RPM configuration to a dump file
+
+``debug-restore``
+    Restore the installed packages to the versions written in the dump file. By
+    default, it does not remove already installed versions of install-only
+    packages and only marks those versions that are mentioned in the dump file
+    for installation. The final decision on which versions to keep on the
+    system is left to dnf and can be fine-tuned using the `installonly_limit`
+    (see :manpage:`dnf.conf(5)`) configuration option.
 
 .. note:: DNF and Yum debug files are not compatible and thus can't be used
           by the other program.
@@ -70,3 +81,8 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
 ``--output``
     Only output list of packages which will be installed or removed.
     No actuall changes are done.
+
+``--remove-installonly``
+    Allow removal of install-only packages. Using this option may result in an
+    attempt to remove the running kernel version (in situations when the currently
+    running kernel version is not part of the dump file).

--- a/doc/debug.rst
+++ b/doc/debug.rst
@@ -57,16 +57,16 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
 
 ``dnf debug-restore``
 
-``--output``
-    Only output list of packages which will be installed or removed.
-    No actuall changes are done.
-
-``--install-latest``
-    When installing use the latest package of the same name and architecture.
+``--filter-types=[install,remove,replace]``
+    Limit package changes to specified type.
 
 ``--ignore-arch``
     When installing package ignore architecture and install missing packages
     matching the name, epoch, version and release.
 
-``--filter-types=[install,remove,replace]``
-    Limit package changes to specified type.
+``--install-latest``
+    When installing use the latest package of the same name and architecture.
+
+``--output``
+    Only output list of packages which will be installed or removed.
+    No actuall changes are done.

--- a/plugins/debug.py
+++ b/plugins/debug.py
@@ -175,6 +175,8 @@ class DebugRestoreCommand(dnf.cli.Command):
         self.cli.demands.sack_activation = True
         self.cli.demands.available_repos = True
         self.cli.demands.root_user = True
+        if not self.opts.output:
+            self.cli.demands.resolving = True
 
     @staticmethod
     def set_argparser(parser):
@@ -206,10 +208,6 @@ class DebugRestoreCommand(dnf.cli.Command):
         self.process_installed(dump_pkgs, self.opts)
 
         self.process_dump(dump_pkgs, self.opts)
-
-        if not self.opts.output:
-            self.base.resolve()
-            self.base.do_transaction()
 
     def process_installed(self, dump_pkgs, opts):
         installed = self.base.sack.query().installed()

--- a/plugins/debug.py
+++ b/plugins/debug.py
@@ -195,6 +195,10 @@ class DebugRestoreCommand(dnf.cli.Command):
             default="install, remove, replace",
             help=_("limit to specified type"))
         parser.add_argument(
+            "--remove-installonly", action="store_true",
+            help=_('Allow removing of install-only packages. Using this option may '
+                   'result in an attempt to remove the running kernel.'))
+        parser.add_argument(
             "filename", nargs=1, help=_("name of dump file"))
 
     def run(self):
@@ -238,10 +242,11 @@ class DebugRestoreCommand(dnf.cli.Command):
                 # package should not be installed
                 pkg_remove = True
             if pkg_remove and "remove" in opts.filter_types:
-                if opts.output:
-                    print("remove    %s" % spec)
-                else:
-                    self.base.package_remove(pkg)
+                if pkg not in installonly_pkgs or opts.remove_installonly:
+                    if opts.output:
+                        print("remove    %s" % spec)
+                    else:
+                        self.base.package_remove(pkg)
 
     def process_dump(self, dump_pkgs, opts):
         for (n, a) in sorted(dump_pkgs.keys()):


### PR DESCRIPTION
- use standard demands.resolving to actually run the transaction
- install-only packages are not removed by default (only when new option --remove-installonly is used)

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/862

The bug: https://bugzilla.redhat.com/show_bug.cgi?id=1844533