### PR TITLE
Move tox.ini -> setup.cfg and increase line length to 120

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@
 # W0503: line break before binary operator
 ignore = C0111,I0011,R0801,R0904,R0911,R0912,R0913,R0903,W0141,W0142,W0212,W0503
 exclude = .git,__pycache__
-max-line-length = 100
+max-line-length = 120


### PR DESCRIPTION
tox.ini is not read by the pep8speaks bot, setup.cfg is. Unifying the
line length limit with what is used in dnf now.