### PR TITLE
copr: don't try to list runtime dependencies

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -300,6 +300,10 @@ Bugzilla. In case of problems, contact the owner of this repository.
             # We skip multilib repositories
             return
 
+        if re.match('coprdep:.*', repo_id):
+            # Runtime dependencies are not listed.
+            return
+
         enabled = repo.enabled
         if (enabled and disabled_only) or (not enabled and enabled_only):
             return


### PR DESCRIPTION
These are not necessarily other copr repositories, but rather any
(external) repositories.  We can not disable them "separately" by
'dnf copr disable', etc.  Printing them in 'dnf copr list' isn't
semantically correct.

Fixes: rhbz#1871373