### PR TITLE
[reposync] Check GPG signatures of downloaded packages (RhBug:1856818) 

### DIFF
--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -39,35 +39,35 @@ Options
 
 All general DNF options are accepted. Namely, the ``--repoid`` option can be used to specify the repositories to synchronize. See `Options` in :manpage:`dnf(8)` for details.
 
-``-p <download-path>, --download-path=<download-path>``
-    Root path under which the downloaded repositories are stored, relative to the current working directory. Defaults to the current working directory. Every downloaded repository has a subdirectory named after its ID under this path.
-    
-``--norepopath``
-    Don't add the reponame to the download path. Can only be used when syncing a single repository (default is to add the reponame).
-
-``--download-metadata``
-    Download all repository metadata. Downloaded copy is instantly usable as a repository, no need to run createrepo_c on it.
-
 ``-a <architecture>, --arch=<architecture>``
     Download only packages of given architectures (default is all architectures). Can be used multiple times.
-
-``--source``
-    Operate on source packages.
-
-``-m, --downloadcomps``
-    Also download and uncompress comps.xml. Consider using ``--download-metadata`` option which will download all available repository metadata.
-
-``-n, --newest-only``
-    Download only newest packages per-repo.
 
 ``--delete``
     Delete local packages no longer present in repository.
 
+``--download-metadata``
+    Download all repository metadata. Downloaded copy is instantly usable as a repository, no need to run createrepo_c on it.
+
+``-m, --downloadcomps``
+    Also download and uncompress comps.xml. Consider using ``--download-metadata`` option which will download all available repository metadata.
+
 ``--metadata-path``
     Root path under which the downloaded metadata are stored. It defaults to ``--download-path`` value if not given.
 
+``-n, --newest-only``
+    Download only newest packages per-repo.
+
+``--norepopath``
+    Don't add the reponame to the download path. Can only be used when syncing a single repository (default is to add the reponame).
+
+``-p <download-path>, --download-path=<download-path>``
+    Root path under which the downloaded repositories are stored, relative to the current working directory. Defaults to the current working directory. Every downloaded repository has a subdirectory named after its ID under this path.
+
 ``--remote-time``
     Try to set the timestamps of the downloaded files to those on the remote side.
+
+``--source``
+    Operate on source packages.
 
 ``-u, --urls``
     Just print urls of what would be downloaded, don't download.

--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -48,6 +48,10 @@ All general DNF options are accepted. Namely, the ``--repoid`` option can be use
 ``--download-metadata``
     Download all repository metadata. Downloaded copy is instantly usable as a repository, no need to run createrepo_c on it.
 
+``-g, --gpgcheck``
+    Remove packages that fail GPG signature checking after downloading. Exit code is ``1`` if at least one package was removed.
+    Note that for repositories with ``gpgcheck=0`` set in their configuration the GPG signature is not checked even with this option used.
+
 ``-m, --downloadcomps``
     Also download and uncompress comps.xml. Consider using ``--download-metadata`` option which will download all available repository metadata.
 

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -63,24 +63,24 @@ class RepoSyncCommand(dnf.cli.Command):
                             help=_('download only packages for this ARCH'))
         parser.add_argument('--delete', default=False, action='store_true',
                             help=_('delete local packages no longer present in repository'))
-        parser.add_argument('-m', '--downloadcomps', default=False, action='store_true',
-                            help=_('also download and uncompress comps.xml'))
         parser.add_argument('--download-metadata', default=False, action='store_true',
                             help=_('download all the metadata.'))
-        parser.add_argument('-n', '--newest-only', default=False, action='store_true',
-                            help=_('download only newest packages per-repo'))
-        parser.add_argument('-p', '--download-path', default='./',
-                            help=_('where to store downloaded repositories'))
-        parser.add_argument('--norepopath', default=False, action='store_true',
-                            help=_("Don't add the reponame to the download path."))
+        parser.add_argument('-m', '--downloadcomps', default=False, action='store_true',
+                            help=_('also download and uncompress comps.xml'))
         parser.add_argument('--metadata-path',
                             help=_('where to store downloaded repository metadata. '
                                    'Defaults to the value of --download-path.'))
-        parser.add_argument('--source', default=False, action='store_true',
-                            help=_('operate on source packages'))
+        parser.add_argument('-n', '--newest-only', default=False, action='store_true',
+                            help=_('download only newest packages per-repo'))
+        parser.add_argument('--norepopath', default=False, action='store_true',
+                            help=_("Don't add the reponame to the download path."))
+        parser.add_argument('-p', '--download-path', default='./',
+                            help=_('where to store downloaded repositories'))
         parser.add_argument('--remote-time', default=False, action='store_true',
                             help=_('try to set local timestamps of local files by '
                                    'the one on the server'))
+        parser.add_argument('--source', default=False, action='store_true',
+                            help=_('operate on source packages'))
         parser.add_argument('-u', '--urls', default=False, action='store_true',
                             help=_("Just list urls of what would be downloaded, "
                                    "don't download"))


### PR DESCRIPTION
YUMv3 reposync used to have --gpgcheck option to remove packages that fail GPG signature checking after downloading.
This patch implements the option for DNF.

https://bugzilla.redhat.com/show_bug.cgi?id=1856818

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/900