### PR TITLE
post-transaction-actions: make execution order predictable

### DIFF
--- a/doc/post-transaction-actions.rst
+++ b/doc/post-transaction-actions.rst
@@ -76,7 +76,12 @@ Each non-comment line defines an action and consists of three items separated by
    The shell command will be evaluated for each package that matched the ``package_filter`` and
    the ``transaction_state``. However, after variable substitution, any duplicate commands will be
    removed and each command will only be executed once per transaction. The order of execution
-   of the commands may differ from the order of packages in the transaction.
+   of the commands follows the order in the action files, but may differ from the order of
+   packages in the transaction.  In other words, when you define several action lines for the
+   same ``package_filter`` these lines will be executed in the order they were defined in the
+   action file when the ``package_filter`` matches a package during the ``trasaction_state`` state.
+   However, the order of when a particular ``package_filter`` is invoked depends on the position
+   of the corresponding package in the transaction.
 
 An example action file:
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/plugins/post-transaction-actions.py
+++ b/plugins/post-transaction-actions.py
@@ -117,7 +117,7 @@ class PostTransactionActions(dnf.Plugin):
                 out_ts_items.append(ts_item)
             all_ts_items.append(ts_item)
 
-        commands_to_run = set()
+        commands_to_run = []
         for (a_key, a_state, a_command) in action_tuples:
             if a_state == "in":
                 ts_items = in_ts_items
@@ -141,7 +141,11 @@ class PostTransactionActions(dnf.Plugin):
                                 if tsi.pkg == pkg and tsi.pkg.reponame == pkg.reponame]
                 ts_item = ts_item_list[0]
                 command = self._replace_vars(ts_item, a_command)
-                commands_to_run.add(command)
+                commands_to_run.append(command)
+
+        # de-dup the list
+        seen = set()
+        commands_to_run = [x for x in commands_to_run if x not in seen and not seen.add(x)]
 
         for command in commands_to_run:
             try:


### PR DESCRIPTION
Currently, the plugin is using a `set` to store commands to be executed.  Unfortunately, `set` is unordered and the execution order cannot be predicted, which makes it difficult to work with actions.

The plugin reads action files and saves them in ordered lists, so changing the `set` to a `list` makes the whole experience much better.  For example, if we have an action file with:

```
/usr/bin/screen:in:echo step 1
/usr/bin/screen:in:echo step 2
/usr/bin/screen:in:echo step 3
```
with the original logic you will see all possible orders of these steps when you install, upgrade, or reinstall the `screen` package.

with the proposed change you will always get steps in the order they are defined.