### PR TITLE
[repomanage] Don't use cached metadata

### DIFF
--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -71,8 +71,11 @@ class RepoManageCommand(dnf.cli.Command):
             raise dnf.exceptions.Error(_("No files to process"))
 
         try:
-            this_repo = self.base.repos.add_new_repo("repomanage_repo", self.base.conf, baseurl=[self.opts.path])
-            self.base._add_repo_to_sack(this_repo)
+            repo_conf = self.base.repos.add_new_repo("repomanage_repo", self.base.conf, baseurl=[self.opts.path])
+            # Always expire the repo, otherwise repomanage could use cached metadata and give identical results
+            # for multiple runs even if the actual repo changed in the meantime
+            repo_conf._repo.expire()
+            self.base._add_repo_to_sack(repo_conf)
             if dnf.base.WITH_MODULES:
                 self.base._setup_modular_excludes()
 

--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -133,7 +133,7 @@ class RepoManageCommand(dnf.cli.Command):
 
             # modular packages
             for streams_by_version in module_dict.values():
-                sorted_stream_versions = sorted(streams_by_version.keys(), reverse=True)
+                sorted_stream_versions = sorted(streams_by_version.keys())
 
                 new_sorted_stream_versions = sorted_stream_versions[-keepnum:]
 
@@ -156,7 +156,7 @@ class RepoManageCommand(dnf.cli.Command):
 
             # modular packages
             for streams_by_version in module_dict.values():
-                sorted_stream_versions = sorted(streams_by_version.keys(), reverse=True)
+                sorted_stream_versions = sorted(streams_by_version.keys())
 
                 old_sorted_stream_versions = sorted_stream_versions[:-keepnum]
 


### PR DESCRIPTION
Always expire the repo, otherwise repomanage could use cached metadata
and give identical results for multiple runs (depending on metadata_expire
config value) even if the actual repo changed in the meantime.

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/913