### PR TITLE
[reposync] Fix downloading uncompressed comps.xml (RhBug:1895059)

### DIFF
--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -218,7 +218,10 @@ class RepoSyncCommand(dnf.cli.Command):
             dest_path = self.metadata_target(repo)
             dnf.util.ensure_dir(dest_path)
             dest = os.path.join(dest_path, 'comps.xml')
-            dnf.yum.misc.decompress(comps_fn, dest=dest)
+            if dnf.yum.misc.decompress(comps_fn, dest=dest) == comps_fn:
+                # in case the comps_fn is plain xml (not compressed) the decompress()
+                # method will not copy the file but just return the original path
+                shutil.copyfile(comps_fn, dest)
             logger.info(_("comps.xml for repository %s saved"), repo.id)
 
     def download_metadata(self, repo):


### PR DESCRIPTION
"reposync -m" command did not copy comps.xml to destination location in
case the group metadata in repository cache was a plain xml file (not
compressed).

https://bugzilla.redhat.com/show_bug.cgi?id=1895059

Test: https://github.com/rpm-software-management/ci-dnf-stack/pull/921