### PR TITLE
add support for spec file templates into builddep subcommand

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -42,6 +42,11 @@ Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 BuildRequires:  cmake
 BuildRequires:  gettext
+
+%if 0%{?rhel} > 7 || 0%{?fedora}
+Recommends:     preproc-rpmspec >= 1.2
+%endif
+
 # Documentation
 %if %{with python3}
 BuildRequires:  %{_bindir}/sphinx-build-3


### PR DESCRIPTION
Hello!

This PR adds support for spec file preprocessing (per https://fedoraproject.org/wiki/Changes/Enable_Spec_File_Preprocessing) into the builddep subcommand.

It uses preproc-rpmspec utillity (at least version 1.2) and also adds `Requires` on it into the spec file. The utility is at the moment on its way to stable repos for epel7, epel8 and all Fedoras (https://bodhi.fedoraproject.org/updates/FEDORA-2020-091d3f026a).

I haven't found a way to run tests, the instructions in `README.rst` don't seem to work (`make test` command errs out with `No rule to make target 'test'.) 

NOTES from the commit:
* uses preproc-rpmspec to render the spec file
* the spec file is only preprocessed if preprocessing is
  enabled by rpkg configuration within the spec file's context
  (i.e. git-toplevel's rpkg.conf and spec's directory rpkg.conf
  are read if present), otherwise the original text is simply
  returned. This is the effect of --check-context option of
  preproc-rpmspec.