### PR TITLE
[reposync] Improve documentation of --source option

### DIFF
--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -71,7 +71,7 @@ All general DNF options are accepted. Namely, the ``--repoid`` option can be use
     Try to set the timestamps of the downloaded files to those on the remote side.
 
 ``--source``
-    Operate on source packages.
+    Download only source packages.
 
 ``-u, --urls``
     Just print urls of what would be downloaded, don't download.

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -84,7 +84,7 @@ class RepoSyncCommand(dnf.cli.Command):
                             help=_('try to set local timestamps of local files by '
                                    'the one on the server'))
         parser.add_argument('--source', default=False, action='store_true',
-                            help=_('operate on source packages'))
+                            help=_('download only source packages'))
         parser.add_argument('-u', '--urls', default=False, action='store_true',
                             help=_("Just list urls of what would be downloaded, "
                                    "don't download"))


### PR DESCRIPTION
Previous description may have implied that user must use the --source
option to download also the source packages and that they will be
excluded otherwise.

The new description is more in line with other options (e.g. --arch or
--newest-only) and implies that the option only limits the reuslt.

= changelog =
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1914827