### PR TITLE
Removed dependency on dnf.yum.misc.Checksum class

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -33,7 +33,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        4.0.19
+Version:        4.0.20
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+
@@ -763,6 +763,9 @@ ln -sf %{_mandir}/man1/%{yum_utils_subpackage_name}.1.gz %{buildroot}%{_mandir}/
 %endif
 
 %changelog
+* Thu Mar 18 2021 Matthew Almond <malmond@fb.com> - 4.0.20-1
+- Removed dependency on dnf.yum.misc.Checksum class (RhBug:1935465)
+
 * Thu Jan 28 2021 Nicola Sella <nsella@redhat.com> - 4.0.19-1
 - copr: allow only 2 arguments with copr enable command
 - [needs-restarting] fix -r in nspawn containers (RhBug:1913962,1914251)

--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -22,6 +22,16 @@ Core DNF Plugins Release Notes
 .. contents::
 
 ====================
+4.0.20 Release Notes
+====================
+- Bug fixes:
+  - Removed dependency on dnf.yum.misc.Checksum class (RhBug:1935465)
+
+Bugs fixed in 4.0.20:
+
+* :rhbug:`1935465`
+
+====================
 4.0.19 Release Notes
 ====================
 

--- a/plugins/config_manager.py
+++ b/plugins/config_manager.py
@@ -25,6 +25,7 @@ import dnf.cli
 import dnf.pycomp
 import dnf.util
 import fnmatch
+import hashlib
 import os
 import re
 import shutil
@@ -253,8 +254,8 @@ def sanitize_url_to_fs(url):
     if len(url) > 250:
         parts = url[:185].split('_')
         lastindex = 185-len(parts[-1])
-        csum = dnf.yum.misc.Checksums(['sha256'])
-        csum.update(url[lastindex:])
+        csum = hashlib.sha256()
+        csum.update(url[lastindex:].encode('utf-8'))
         url = url[:lastindex] + '_' + csum.hexdigest()
     # remove all not allowed characters
     allowed_regex = "[^abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_.:-]"


### PR DESCRIPTION
 https://github.com/rpm-software-management/dnf/pull/1743 removes code this package uses, so we replaced it. We need to ensure that dnf does not permit version of this package before 4.0.20 to be installed else they will not be able to resolve the class. See https://github.com/rpm-software-management/dnf/pull/1743#pullrequestreview-615177905 for context.
