### PR TITLE
Turn off dnf_local by default

### DIFF
--- a/etc/dnf/plugins/local.conf
+++ b/etc/dnf/plugins/local.conf
@@ -1,5 +1,5 @@
 [main]
-enabled = true
+enabled = false
 # Path to the local repository.
 # repodir = /var/lib/dnf/plugins/local
 


### PR DESCRIPTION
DNF plugin local not provides /var/ lib/DNF/plugins/local/, so exec command "yum list" after installation will prompt the following errors:
![image](https://user-images.githubusercontent.com/75836904/125233786-e6bc9580-e311-11eb-878a-3671b85d8c3d.png)
