### PR TITLE
Fix baseurl for centos stream chroot

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -458,6 +458,8 @@ Bugzilla. In case of problems, contact the owner of this repository.
                 chroot = ("opensuse-tumbleweed-{}".format(distarch))
             else:
                 chroot = ("opensuse-leap-{0}-{1}".format(dist[1], distarch))
+        elif "CentOS Stream" in dist:
+            chroot = ("centos-stream-{0}-{1}".format(dist[1], distarch))
         else:
             chroot = ("epel-%s-x86_64" % dist[1].split(".", 1)[0])
         return chroot


### PR DESCRIPTION
= changelog =
msg: dnf copr enable on CentOS Stream should enable centos stream chroot, not epel 8
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1994154