### PR TITLE
reposync: Use fail_fast=False when downloading packages (RhBug:2009894)

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.2.22}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.9.2}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.46.1
 %global yum_utils_subpackage_name dnf-utils

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -303,7 +303,7 @@ class RepoSyncCommand(dnf.cli.Command):
                                   progress, 0)
         payloads = [RPMPayloadLocation(pkg, progress, self.pkg_download_path(pkg))
                     for pkg in pkglist]
-        base._download_remote_payloads(payloads, drpm, progress, None)
+        base._download_remote_payloads(payloads, drpm, progress, None, False)
 
     def print_urls(self, pkglist):
         for pkg in pkglist:


### PR DESCRIPTION
Requires: https://github.com/rpm-software-management/dnf/pull/1790

= changelog =
msg:           Reposync does not stop downloading packages on the first error
type:          bugfix
resolves:      https://bugzilla.redhat.com/show_bug.cgi?id=2009894