### PR TITLE
reposync: Implement --safe-write-path option (RhBug:1898089)

### DIFF
--- a/doc/reposync.rst
+++ b/doc/reposync.rst
@@ -67,6 +67,9 @@ All general DNF options are accepted. Namely, the ``--repoid`` option can be use
 ``-p <download-path>, --download-path=<download-path>``
     Root path under which the downloaded repositories are stored, relative to the current working directory. Defaults to the current working directory. Every downloaded repository has a subdirectory named after its ID under this path.
 
+``--safe-write-path``
+    Specify the filesystem path prefix under which the reposync is allowed to write. If not specified it defaults to download path of the repository. Useful for repositories that use relative locations of packages out of repository directory (e.g. "../packages_store/foo.rpm"). Use with care, any file under the ``safe-write-path`` can be overwritten. Can be only used when syncing a single repository.
+
 ``--remote-time``
     Try to set the timestamps of the downloaded files to those on the remote side.
 


### PR DESCRIPTION
By default reposync is not allowed to write files outside of repository download path (by default ./<repo id>). But there are some repositories that store packages using relative parent paths (e.g. ../packages-store/f/foo.rpm).
This patch introduces new --safe-write-path option that can override this limitation and set a root directory that is considered safe for writing.
For example `dnf reposync --repoid=the_repo --safe-write-path=.` will allow reposync to write files not only to `./the_repo` directory but also to current working directory itself.

= changelog =
msg: With --safe-write-path option reposync can download repositories with relative package locations (like ../package-store/f/foo.rpm)
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1898089