### PR TITLE
copr: allow specifying protocol as part of --hub

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -189,8 +189,12 @@ class CoprCommand(dnf.cli.Command):
                     self.copr_hostname += ":" + port
 
         if not self.copr_url:
-            self.copr_hostname = copr_hub
-            self.copr_url = self.default_protocol + "://" + copr_hub
+            if '://' not in copr_hub:
+                self.copr_hostname = copr_hub
+                self.copr_url = self.default_protocol + "://" + copr_hub
+            else:
+                self.copr_hostname = copr_hub.split('://', 1)[1]
+                self.copr_url = copr_hub
 
     def _read_config_item(self, config, hub, section, default):
         try:


### PR DESCRIPTION
This way it doesn't try to connect to `https://http//url` if `--hub` started with `http://`.