### PR TITLE
copr: don't traceback on empty lines in /etc/os-release

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -54,8 +54,13 @@ except ImportError:
             with open('/etc/os-release') as os_release_file:
                 os_release_data = {}
                 for line in os_release_file:
-                    os_release_key, os_release_value = line.rstrip().split('=')
-                    os_release_data[os_release_key] = os_release_value.strip('"')
+                    try:
+                        os_release_key, os_release_value = line.rstrip().split('=')
+                        os_release_data[os_release_key] = os_release_value.strip('"')
+                    except ValueError:
+                        # Skip empty lines and everything that is not a simple
+                        # variable assignment
+                        pass
                 return (os_release_data['NAME'], os_release_data['VERSION_ID'], None)
 
 PLUGIN_CONF = 'copr'


### PR DESCRIPTION
Fix RHBZ 1994944