### PR TITLE
groups-manager: More benevolent resolving of packages (RhBug:2013633)

### DIFF
--- a/plugins/groups_manager.py
+++ b/plugins/groups_manager.py
@@ -254,7 +254,9 @@ class GroupsManagerCommand(dnf.cli.Command):
             # find packages according to specifications from command line
             packages = set()
             for pkg_spec in self.opts.packages:
-                q = self.base.sack.query().filterm(name__glob=pkg_spec).latest()
+                subj = dnf.subject.Subject(pkg_spec)
+                q = subj.get_best_query(self.base.sack, with_nevra=True,
+                                        with_provides=False, with_filenames=False).latest()
                 if not q:
                     logger.warning(_("No match for argument: {}").format(pkg_spec))
                     continue


### PR DESCRIPTION
= changelog =
msg: groups-manager uses for matching packages full NEVRA and not only name.
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2013633