### PR TITLE
Add counts of missing deps

### DIFF
--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -53,17 +53,23 @@ class RepoClosureCommand(dnf.cli.Command):
                     repo.enable()
 
     def run(self):
+        total_missing = 0
         if self.opts.arches:
             unresolved = self._get_unresolved(self.opts.arches)
         else:
             unresolved = self._get_unresolved()
         for pkg in sorted(unresolved.keys()):
             print("package: {} from {}".format(str(pkg), pkg.reponame))
-            print("  unresolved deps:")
+            print("  unresolved deps ({}):".format(len(unresolved[pkg])))
+            total_missing += len(unresolved[pkg])
             for dep in unresolved[pkg]:
                 print("    {}".format(dep))
         if len(unresolved) > 0:
-            msg = _("Repoclosure ended with unresolved dependencies.")
+            msg = _(
+                "Repoclosure ended with unresolved dependencies ({}) across {} packages.".format(
+                    total_missing, len(unresolved)
+                )
+            )
             raise dnf.exceptions.Error(msg)
 
     def _get_unresolved(self, arch=None):

--- a/tests/test_repoclosure.py
+++ b/tests/test_repoclosure.py
@@ -50,10 +50,10 @@ class TestRepoClosureFunctions(support.TestCase):
                 support.command_run(self.cmd, args)
 
             self.assertEqual(context.exception.value,
-                             "Repoclosure ended with unresolved dependencies.")
+                             "Repoclosure ended with unresolved dependencies (1) across 1 packages.")
 
             expected_out = ["package: foo-4-6.noarch from @commandline",
-                            "  unresolved deps:",
+                            "  unresolved deps (1):",
                             "    bar = 4-6"]
             self.assertEqual(stdout.getvalue()[:-1], "\n".join(expected_out))
         args = ["--check", "main"]
@@ -69,10 +69,10 @@ class TestRepoClosureFunctions(support.TestCase):
                 support.command_run(self.cmd, args)
 
             self.assertEqual(context.exception.value,
-                             "Repoclosure ended with unresolved dependencies.")
+                             "Repoclosure ended with unresolved dependencies (1) across 1 packages.")
 
             expected_out = ["package: foo-4-6.noarch from @commandline",
-                            "  unresolved deps:",
+                            "  unresolved deps (1):",
                             "    bar = 4-6"]
             self.assertEqual(stdout.getvalue()[:-1], "\n".join(expected_out))
         args = ["--pkg", "bar"]
@@ -89,9 +89,9 @@ class TestRepoClosureFunctions(support.TestCase):
                 support.command_run(self.cmd, args)
 
             self.assertEqual(context.exception.value,
-                             "Repoclosure ended with unresolved dependencies.")
+                             "Repoclosure ended with unresolved dependencies (1) across 1 packages.")
 
             expected_out = ["package: foo-4-6.noarch from @commandline",
-                            "  unresolved deps:",
+                            "  unresolved deps (1):",
                             "    bar = 4-6"]
             self.assertEqual(stdout.getvalue()[:-1], "\n".join(expected_out))


### PR DESCRIPTION
For reviewing repoclosure results, it is handy to have raw counts sometimes.  Incremental fixes are easier to identify when you can see the numbers going down.