### PR TITLE
plugin debug: Use base._ts.dbCookie() to determining rpmdb version

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -1,4 +1,4 @@
-%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.10.1}
+%{?!dnf_lowest_compatible: %global dnf_lowest_compatible 4.11.0}
 %global dnf_plugins_extra 2.0.0
 %global hawkey_version 0.64.0
 %global yum_utils_subpackage_name dnf-utils
@@ -33,7 +33,7 @@
 %endif
 
 Name:           dnf-plugins-core
-Version:        4.0.25
+Version:        4.0.26
 Release:        1%{?dist}
 Summary:        Core Plugins for DNF
 License:        GPLv2+

--- a/plugins/debug.py
+++ b/plugins/debug.py
@@ -161,7 +161,7 @@ class DebugDumpCommand(dnf.cli.Command):
 
     def dump_rpmdb_versions(self):
         self.write("%%%%RPMDB VERSIONS\n")
-        version = self.base.sack._rpmdb_version()
+        version = self.base._ts.dbCookie()
         self.write("  all: %s\n" % version)
         return
 


### PR DESCRIPTION
The debug plugin used `base.sack._rpmdb_version()` method. Which is actually the private method hawkey.Sack._rpmdb_version()` from libdnf.

The patch uses the `base._ts.dbCookie()` method. This method was added to DNF 4.11.0. And internally it calls the new official API function `rpm.TransactionSet.dbCookie()` from librpm. This is a necessary step to allow the `._rpmdb_version()` method to be removed from libdnf.

Requires: https://github.com/rpm-software-management/dnf/pull/1811