### PR TITLE
Skip all non rpm tsi for transaction_action plugins (rhbug:2023652)

### DIFF
--- a/plugins/post-transaction-actions.py
+++ b/plugins/post-transaction-actions.py
@@ -115,6 +115,9 @@ class PostTransactionActions(dnf.Plugin):
                 in_ts_items.append(ts_item)
             elif ts_item.action in dnf.transaction.BACKWARD_ACTIONS:
                 out_ts_items.append(ts_item)
+            else:
+                #  The action is not rpm change. It can be a reason change, therefore we can skip that item
+                continue
             all_ts_items.append(ts_item)
 
         commands_to_run = []


### PR DESCRIPTION
It prevent traceback in output when reason change is in transaction

CI test: https://github.com/rpm-software-management/ci-dnf-stack/pull/1093