### PR TITLE
repomanage: Use modules only from repo they are handling

### DIFF
--- a/plugins/repomanage.py
+++ b/plugins/repomanage.py
@@ -72,7 +72,8 @@ class RepoManageCommand(dnf.cli.Command):
         keepnum = int(self.opts.keep) # the number of items to keep
 
         try:
-            repo_conf = self.base.repos.add_new_repo("repomanage_repo", self.base.conf, baseurl=[self.opts.path])
+            REPOMANAGE_REPOID = "repomanage_repo"
+            repo_conf = self.base.repos.add_new_repo(REPOMANAGE_REPOID, self.base.conf, baseurl=[self.opts.path])
             # Always expire the repo, otherwise repomanage could use cached metadata and give identical results
             # for multiple runs even if the actual repo changed in the meantime
             repo_conf._repo.expire()
@@ -84,9 +85,13 @@ class RepoManageCommand(dnf.cli.Command):
                 module_packages = self.base._moduleContainer.getModulePackages()
 
                 for module_package in module_packages:
-                    all_modular_artifacts.update(module_package.getArtifacts())
-                    module_dict.setdefault(module_package.getNameStream(), {}).setdefault(
-                        module_package.getVersionNum(), []).append(module_package)
+                    # Even though we load only REPOMANAGE_REPOID other modules can be loaded from system
+                    # failsafe data automatically, we don't want them affecting repomanage results so ONLY
+                    # use modules from REPOMANAGE_REPOID.
+                    if module_package.getRepoID() == REPOMANAGE_REPOID:
+                        all_modular_artifacts.update(module_package.getArtifacts())
+                        module_dict.setdefault(module_package.getNameStream(), {}).setdefault(
+                            module_package.getVersionNum(), []).append(module_package)
 
         except dnf.exceptions.RepoError:
             rpm_list = []


### PR DESCRIPTION
= changelog =
msg: [repomanage/reposync] Modules are used only when they belong to target repo
type: bugfix
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2072441

Tests: https://github.com/rpm-software-management/ci-dnf-stack/pull/1094