### PR TITLE
builddep: Warning when using macros with source rpms

### DIFF
--- a/doc/builddep.rst
+++ b/doc/builddep.rst
@@ -31,7 +31,7 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
     Show this help.
 
 ``-D <macro expr>, --define <macro expr>``
-    Define the RPM macro named `macro` to the value `expr` when parsing spec files.
+    Define the RPM macro named `macro` to the value `expr` when parsing spec files. Does not apply for source rpm files.
 
 ``--spec``
     Treat arguments as .spec files.

--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -204,6 +204,10 @@ class BuildDepCommand(dnf.cli.Command):
             err = _("Not all dependencies satisfied")
             raise dnf.exceptions.Error(err)
 
+        if self.opts.define:
+            logger.warning(_("Warning: -D or --define arguments have no meaning "
+                             "for source rpm packages."))
+
     def _spec_deps(self, spec_fn):
         try:
             spec = rpm.spec(spec_fn)


### PR DESCRIPTION
Defining RPM macros in `builddep` command is not supported for source rpms. Therefore adding note into man page and warning when using the `-D` or `--define` argument with source rpm.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2077820.