### PR TITLE
copr: Acknowledge downstream compatibility for non-EPEL distros

### DIFF
--- a/doc/copr.rst
+++ b/doc/copr.rst
@@ -80,6 +80,7 @@ Configuration (copr)
 
 ``/etc/dnf/plugins/copr.conf``
 ``/etc/dnf/plugins/copr.d/``
+``/usr/share/dnf/plugins/copr.vendor.conf``
 
 Configuration file should contain a section for each hub, each section having ``hostname``
  (mandatory), ``protocol`` (default ``https``) and ``port`` (default ``443``) parameters.::
@@ -89,6 +90,14 @@ Configuration file should contain a section for each hub, each section having ``
   protocol = https
   port = 443
 
+
+There is also a vendor configuration that allows a vendor to specify the distro ID that copr should use by default.
+This is useful for vendors that want to use Copr for their own distro. The vendor configuration is in
+``/usr/share/dnf/plugins/copr.vendor.conf`` (optional) or ``/etc/dnf/plugins/copr.conf``::
+
+  [main]
+  distribution = fedora
+  releasever = 37
 ----------------------
 Arguments (playground)
 ----------------------


### PR DESCRIPTION
= changelog =
msg: [copr] Also read chroot configs from other files in copr.conf.d
type: enhancement
resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2091662


This PR is an alternative solution to #458, which allows other config files to override the main Copr config for chroot configs in the `[main]` section.

It adds a new optional config file called `copr.vendor.conf` that allows vendors to specify what distro their downstream is compatible with on COPR. This solves issues regarding COPR on Ultramarine Linux, Nobara, and risiOS.