### PR TITLE
download plugin: respect install_weak_deps option value

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -253,7 +253,7 @@ class DownloadCommand(dnf.cli.Command):
         for pkg in pkgs:
             goal = hawkey.Goal(self.base.sack)
             goal.install(pkg)
-            rc = goal.run()
+            rc = goal.run(ignore_weak_deps=(not self.base.conf.install_weak_deps))
             if rc:
                 pkg_set.update(goal.list_installs())
                 pkg_set.update(goal.list_upgrades())


### PR DESCRIPTION
Currently, `dnf download --resolve` will always download weak dependencies, disregarding the `install_weak_deps` option value: _(tested in AlmaLinux 9.0 container)_

```
$ dnf download --setopt=install_weak_deps=0 --url --alldeps --resolve kernel | wc -l
121
$ dnf download --setopt=install_weak_deps=1 --url --alldeps --resolve kernel | wc -l
121
```

With this trivial patch it works as user may expect it to work - not downloading linux-firmware and few other packages:

```
$ dnf download --setopt=install_weak_deps=0 --url --alldeps --resolve kernel | wc -l
116
$ dnf download --setopt=install_weak_deps=1 --url --alldeps --resolve kernel | wc -l
121
```
