### PR TITLE
offline-upgrade: add support for security filters (RhBug:1939975)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,6 +32,7 @@ DNF-PLUGINS-CORE CONTRIBUTORS
     Neal Gompa <ngompa13@gmail.com>
     Paul Howarth <paul@city-fan.org>
     Rickard Dybeck <r.dybeck@gmail.com>
+    Tarcísio Ladeia de Oliveira <wyrquill@gmail.com>
     Tomas Babej <tomasbabej@gmail.com>
     Vladan Kudlac <vladankudlac@gmail.com>
     Wieland Hoffmann <themineo@gmail.com>

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -467,6 +467,9 @@ class SystemUpgradeCommand(dnf.cli.Command):
                     logger.error(_("Operation aborted."))
                     sys.exit(1)
             check_release_ver(self.base.conf, target=self.opts.releasever)
+        elif 'offline-upgrade' == self.opts.command:
+            self.cli._populate_update_security_filter(self.opts)
+
         self.cli.demands.root_user = True
         self.cli.demands.resolving = True
         self.cli.demands.available_repos = True


### PR DESCRIPTION
Adding security filter support makes it easier and safer, for example, to upgrade select packages from `updates-testing` and other testing repositories. I stumbled into this while testing updates from Bodhi, and also found a bug report about it from last year [(RhBug:1939975)](https://bugzilla.redhat.com/show_bug.cgi?id=1939975).

It's a two-line change, enabling it only for `offline-upgrade`. I tested it by refreshing the metadata using the four available filter options (`--advisory`, `--bugfix`, `--security`, and `--enhancement`) and it did filter them correctly. I downloaded a single package using `--advisory` and it installed correctly on boot. Other non-upgraded packages where left unchanged, and the package is working correctly.

I was not sure if I should update the documentation or not so I just committed the source changes, but I can update it if needed.