### PR TITLE
Fix boot time calculation.

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -34,6 +34,7 @@ import functools
 import os
 import re
 import stat
+import time
 
 
 # For which package updates we should recommend a reboot
@@ -199,7 +200,14 @@ class ProcessStart(object):
 
     @staticmethod
     def get_boot_time():
-        return int(os.stat('/proc/1').st_mtime)
+        if os.path.isfile('/proc/uptime'):
+            with open('/proc/uptime', 'rb') as f:
+                uptime = f.readline().strip().split()[0].strip()
+                time_now = time.time()
+                return int(time_now - float(uptime))
+        else:
+            print(_('Unable to calculate uptime'))
+            raise dnf.exceptions.Error()
 
     @staticmethod
     def get_sc_clk_tck():


### PR DESCRIPTION
  * The timestamp of reading '/proc/1' comes from the kernel boot time, however this timestamp can be interpreted into different time depending on the BIOS/UEFI setting and the timezone of the system.
  * Update the method of boot time calculation.