### PR TITLE
Allow the local plugin to exclude packages from the local cache repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ TAGS
 *~
 build/
 libexec/dnf-utils
+libexec/dnf-utils-3

--- a/plugins/local.py
+++ b/plugins/local.py
@@ -26,6 +26,7 @@ from dnfpluginscore import _, logger
 
 import dnf
 import dnf.cli
+import dnf.repo
 import os
 import shutil
 import subprocess
@@ -62,6 +63,8 @@ class LocalConfParse(object):
                                              default="/var/lib/dnf/plugins/local")
         else:
             raise KeyError("Disabled")
+
+        main["exclude"] = self.get_value("main", "exclude", "")
 
         if crepo["enabled"]:
             crepo["cachedir"] = self.get_value("createrepo", "cachedir")
@@ -103,6 +106,7 @@ class Local(dnf.Plugin):
 
         local_repo = dnf.repo.Repo("_dnf_local", self.base.conf)
         local_repo.baseurl = "file://{}".format(self.main["repodir"])
+        local_repo.exclude = self.main["exclude"]
         local_repo.cost = 500
         local_repo.skip_if_unavailable = True
         self.base.repos.add(local_repo)


### PR DESCRIPTION
When using the local plugin as a cache for multiple guest machines, packages that might get installed in the guest that are ignored on the host will end up bypassing the `exclude` filters in the repo configs on the host. 

This change allows the `exclude` option to be configured in the local plugin so that these packages will still be excluded from installation. 