### PR TITLE
system-upgrade: Drop warning in upstream

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -148,13 +148,14 @@ Summary:    Core Plugins for DNF
 %{?python_provide:%python_provide python3-%{name}}
 BuildRequires:  python3-dbus
 BuildRequires:  python3-devel
-BuildRequires:  python3-distro
 BuildRequires:  python3-dnf >= %{dnf_lowest_compatible}
 BuildRequires:  python3-systemd
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  systemd
 %{?systemd_ordering}
+%if 0%{?fedora}
 Requires:       python3-distro
+%endif
 Requires:       python3-dbus
 Requires:       python3-dnf >= %{dnf_lowest_compatible}
 Requires:       python3-hawkey >= %{hawkey_version}

--- a/doc/system-upgrade.rst
+++ b/doc/system-upgrade.rst
@@ -34,8 +34,6 @@ is fully upgraded (``dnf --refresh upgrade``).
 The ``system-upgrade`` command also performes additional actions necessary for the upgrade of the
 system, for example an upgrade of groups and environments.
 
-.. WARNING:: The ``system-upgrade`` command is not supported on the RHEL distribution.
-
 --------
 Synopsis
 --------

--- a/plugins/system_upgrade.py
+++ b/plugins/system_upgrade.py
@@ -20,7 +20,6 @@
 """system_upgrade.py - DNF plugin to handle major-version system upgrades."""
 
 from subprocess import call, Popen, check_output, CalledProcessError
-import distro
 import json
 import os
 import os.path
@@ -460,9 +459,6 @@ class SystemUpgradeCommand(dnf.cli.Command):
 
     def configure_download(self):
         if 'system-upgrade' == self.opts.command or 'fedup' == self.opts.command:
-            if distro.id() == 'rhel':
-                logger.warning(_('WARNING: this operation is not supported on the RHEL distribution. '
-                                 'Proceed at your own risk.'))
             help_url = get_url_from_os_release()
             if help_url:
                 msg = _('Additional information for System Upgrade: {}')


### PR DESCRIPTION
The `distro` package is not available in the minimal installation of related downstreams where the warning should be displayed. Therefore dropping the implementation from the upstream and affected distributions will handle the situation by themselves.

related link: https://bugzilla.redhat.com/show_bug.cgi?id=2152846