### PR TITLE
Run dnf-plugins-core (dnf4) CI againts dnf-4-stack branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rpm-software-management/ci-dnf-stack
+          ref: dnf-4-stack
 
       - name: Setup CI
         id: setup-ci
@@ -48,6 +49,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rpm-software-management/ci-dnf-stack
+          ref: dnf-4-stack
 
       - name: Run Integration Tests
         uses: ./.github/actions/integration-tests
@@ -66,6 +68,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: rpm-software-management/ci-dnf-stack
+          ref: dnf-4-stack
 
       - name: Run Ansible Tests
         uses: ./.github/actions/ansible-tests


### PR DESCRIPTION
Since we have a separate branch for dnf4 in `ci-dnf-stack` use it to run integration tests.