### PR TITLE
Allow reposync to download from Amazon Linux repos

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ DNF-PLUGINS-CORE CONTRIBUTORS
     Vladan Kudlac <vladankudlac@gmail.com>
     Wieland Hoffmann <themineo@gmail.com>
     Otto Urpelainen <oturpe@iki.fi>
+    Mansi Jaitly <mjaitly@amazon.com>

--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -23,6 +23,7 @@ from __future__ import unicode_literals
 
 import hawkey
 import os
+import re
 import shutil
 import types
 
@@ -186,8 +187,9 @@ class RepoSyncCommand(dnf.cli.Command):
 
     def pkg_download_path(self, pkg):
         repo_target = self.repo_target(pkg.repo)
+        fix_path_re = re.compile(r"^(?:../)+blobstore/[a-fA-F0-9]{64}/")
         pkg_download_path = os.path.realpath(
-            os.path.join(repo_target, pkg.location))
+            os.path.join(repo_target, fix_path_re.sub('', pkg.location)))
         # join() ensures repo_target ends with a path separator (otherwise the
         # check would pass if pkg_download_path was a "sibling" path component
         # of repo_target that has the same prefix).


### PR DESCRIPTION
The yum repository layout for Amazon Linux repositories (AL1, AL2,
AL2023, and likely future versions) have an interesting layout.

All Amazon Linux releases have a mirrorlist that points to the
repository. This repository is not in a fixed location but instead under
a GUID. It allows content syncing (and staged) before the atomic (and
fast) operation of writing a new mirrorlist making the content visible.

GUID-based repository wasn't an issue for Amazon Linux 1
repositories as the GUID repos were a complete copy of the repository.
But as the "updates" repo grew, the time it took to release package
updates increased.

Starting with Amazon Linux 2, instead of having each GUID repo have a
full copy of the repository, the repodata contains relative paths over
to a central blobstore. Thus the only data pushed to release a package
update are the added packages and a new copy of the repo metadata.
However, as of caf28c4, reposync does not want to write files outside
the destination directory. It broke the ability to reposync the Amazon
Linux 2 style yum repositories.

This patch updates the package download path per regular expression
(r"^(?:../)+blobstore/[a-fA-F0-9]{64}/"). The regular expression
substitution removes the blobstore-GUID path. It does keep the
downloading file within a sub-directory structure if present.