### PR TITLE
ConfigParser.substitute

### DIFF
--- a/plugins/post-transaction-actions.py
+++ b/plugins/post-transaction-actions.py
@@ -101,7 +101,7 @@ class PostTransactionActions(dnf.Plugin):
                    "repoid": ts_item.from_repo,
                    "state": action}
 
-        result = libdnf.conf.ConfigParser_substitute(command, vardict)
+        result = libdnf.conf.ConfigParser.substitute(command, vardict)
         return result
 
     def transaction(self):


### PR DESCRIPTION
Prevent " AttributeError: module 'libdnf.conf' has no attribute 'ConfigParser_substitute'"