### PR TITLE
yum-utils: only depend on python3-dnf, not dnf

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -196,7 +196,6 @@ Provides:       yum-utils = %{version}-%{release}
 Provides:       dnf-utils = %{version}-%{release}
 Obsoletes:      dnf-utils < %{version}-%{release}
 %endif
-Requires:       dnf >= %{dnf_lowest_compatible}
 Requires:       %{name} = %{version}-%{release}
 %if %{with python3}
 Requires:       python3-dnf >= %{dnf_lowest_compatible}

--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -14,7 +14,7 @@ OnFailure=dnf-system-upgrade-cleanup.service
 Type=oneshot
 # Upgrade output goes to journal and on-screen.
 StandardOutput=journal+console
-ExecStart=/usr/bin/dnf system-upgrade upgrade
+ExecStart=/usr/bin/dnf-3 system-upgrade upgrade
 
 [Install]
 WantedBy=system-update.target


### PR DESCRIPTION
Part of the DNF -> DNF5 upgrade path; https://github.com/rpm-software-management/dnf5/issues/416

The `dnf` package only supplies the `dnf` binary; the plugins/utilities in `yum-utils` should only need the libraries in `python3-dnf`, not the `dnf` binary. `python3-dnf` and `dnf5` can be installed simultaneously, but `dnf` and `dnf5` conflict.