### PR TITLE
Avoid a long obsolete rpm API use

### DIFF
--- a/plugins/builddep.py
+++ b/plugins/builddep.py
@@ -192,7 +192,7 @@ class BuildDepCommand(dnf.cli.Command):
             os.close(fd)
             raise dnf.exceptions.Error(e)
         os.close(fd)
-        ds = h.dsFromHeader('requirename')
+        ds = rpm.ds(h, 'requirename')
         done = True
         for dep in ds:
             reldep_str = self._rpm_dep2reldep_str(dep)


### PR DESCRIPTION
dsFromHeader() and dsOfHeader() header methods were removed in rpm 4.19, passing header to rpm.ds constructor is the preferred way since rpm 4.8 / RHEL 6.