### PR TITLE
needs-restarting: Small refinement of NoUnitForPID handling

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -138,20 +138,23 @@ def get_service_dbus(pid):
         systemd_manager_object,
         'org.freedesktop.systemd1.Manager'
     )
-    service_proxy = None
+
+    service_unit_path = None
     try:
-        service_proxy = bus.get_object(
-            'org.freedesktop.systemd1',
-            systemd_manager_interface.GetUnitByPID(pid)
-        )
+        service_unit_path = systemd_manager_interface.GetUnitByPID(pid)
     except dbus.DBusException as e:
         # There is no unit for the pid. Usually error is 'NoUnitForPid'.
         # Considering what we do at the bottom (just return if not service)
         # Then there's really no reason to exit here on that exception.
         # Log what's happened then move on.
         msg = str(e)
-        logger.warning("Failed to get systemd unit for PID {}: {}".format(pid, msg))
-        return
+        if msg.startswith('org.freedesktop.systemd1.NoUnitForPID'):
+            logger.warning("Failed to get systemd unit for PID {}: {}".format(pid, msg))
+            return
+        else:
+            raise
+
+    service_proxy = bus.get_object('org.freedesktop.systemd1', service_unit_path)
     service_properties = dbus.Interface(
         service_proxy, dbus_interface="org.freedesktop.DBus.Properties")
     name = service_properties.Get(


### PR DESCRIPTION
Limit handling of the issue to only this specific use case, otherwise throw the exception as any other DBUS-related call.

Follow-up to the fix from https://github.com/rpm-software-management/dnf-plugins-core/pull/487.