### PR TITLE
system-upgrade: Wait until the upgrade is done before poweroff (RhBug:2211844)

### DIFF
--- a/etc/systemd/dnf-system-upgrade.service
+++ b/etc/systemd/dnf-system-upgrade.service
@@ -6,7 +6,7 @@ Documentation=http://www.freedesktop.org/wiki/Software/systemd/SystemUpdates
 DefaultDependencies=no
 Requires=sysinit.target
 After=sysinit.target systemd-journald.socket system-update-pre.target
-Before=shutdown.target system-update.target
+Before=poweroff.target reboot.target shutdown.target system-update.target
 OnFailure=dnf-system-upgrade-cleanup.service
 
 [Service]


### PR DESCRIPTION
Add a systemd dependency to wait until upgrade service is finished before executing the poweroff when passing the `--poweroff` option in `system-upgrade` plugin.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2211844