### PR TITLE
[needs-restarting] add kernel-core to reboot list

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -39,8 +39,9 @@ import time
 
 # For which package updates we should recommend a reboot
 # Mostly taken from https://access.redhat.com/solutions/27943
-NEED_REBOOT = ['kernel', 'kernel-rt', 'glibc', 'linux-firmware',
-               'systemd', 'dbus', 'dbus-broker', 'dbus-daemon']
+NEED_REBOOT = ['kernel', 'kernel-core', 'kernel-rt', 'glibc',
+               'linux-firmware', 'systemd', 'dbus', 'dbus-broker',
+               'dbus-daemon']
 
 def get_options_from_dir(filepath, base):
     """


### PR DESCRIPTION
A host might reasonably have only kernel-core installed without kernel-modules or the kernel metapackage installed.