### PR TITLE
needs-restarting: Add microcode_ctl to a reboot list

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -40,7 +40,8 @@ import time
 # For which package updates we should recommend a reboot
 # Mostly taken from https://access.redhat.com/solutions/27943
 NEED_REBOOT = ['kernel', 'kernel-rt', 'glibc', 'linux-firmware',
-               'systemd', 'dbus', 'dbus-broker', 'dbus-daemon']
+               'systemd', 'dbus', 'dbus-broker', 'dbus-daemon',
+               'microcode_ctl']
 
 NEED_REBOOT_DEPENDS_ON_DBUS = ['zlib']
 


### PR DESCRIPTION
commit 9f46488c6b1ac553989a3fd8a9ea18271451c5e8 upstream.

To fully update CPU microcode, a reboot is needed because the microcode update should be applied before starting a kernel and other process.

Therefore recommend a reboot after installing or updating microcode_ctl package.

https://issues.redhat.com/browse/RHEL-17356