### PR TITLE
Request filelists metadata for plugins needing that

### DIFF
--- a/plugins/download.py
+++ b/plugins/download.py
@@ -91,6 +91,9 @@ class DownloadCommand(dnf.cli.Command):
         else:
             self.base.conf.destdir = dnf.i18n.ucd(os.getcwd())
 
+        if dnf.util._is_file_pattern_present(self.opts.packages):
+            self.base.conf.optional_metadata_types += ["filelists"]
+
     def run(self):
         """Execute the util action here."""
 

--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -268,6 +268,7 @@ class NeedsRestartingCommand(dnf.cli.Command):
     def configure(self):
         demands = self.cli.demands
         demands.sack_activation = True
+        self.base.conf.optional_metadata_types += ["filelists"]
 
     def run(self):
         process_start = ProcessStart()

--- a/plugins/repoclosure.py
+++ b/plugins/repoclosure.py
@@ -45,6 +45,7 @@ class RepoClosureCommand(dnf.cli.Command):
         demands = self.cli.demands
         demands.sack_activation = True
         demands.available_repos = True
+        self.base.conf.optional_metadata_types += ["filelists"]
         if self.opts.repo:
             for repo in self.base.repos.all():
                 if repo.id not in self.opts.repo and repo.id not in self.opts.check:


### PR DESCRIPTION
Prepare for switching to not loading filelists metadata by default. Explicitly request the metadata by plugins that need them.

Requires: https://github.com/rpm-software-management/dnf/pull/2012.
Targetted for: https://issues.redhat.com/browse/RHEL-12355.