### PR TITLE
needs-restarting: Get process start time by /proc/pid mtime

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -266,12 +266,7 @@ class ProcessStart(object):
         return os.sysconf(os.sysconf_names['SC_CLK_TCK'])
 
     def __call__(self, pid):
-        stat_fn = '/proc/%d/stat' % pid
-        with open(stat_fn) as stat_file:
-            stats = stat_file.read().strip().split()
-        ticks_after_boot = int(stats[21])
-        secs_after_boot = ticks_after_boot // self.sc_clk_tck
-        return self.boot_time + secs_after_boot
+        return int(os.stat(f"/proc/{pid}").st_mtime)
 
 
 @dnf.plugin.register_command


### PR DESCRIPTION
The previous method of getting a process's start time was to add the boot time detected by `ProcessStart.get_boot_time` to the process's `starttime`:

[man 5 proc](https://man7.org/linux/man-pages/man5/proc.5.html)
```
              (22) starttime  %llu
                     The time the process started after system boot.
                     Before Linux 2.6, this value was expressed in
                     jiffies.  Since Linux 2.6, the value is expressed
                     in clock ticks (divide by sysconf(_SC_CLK_TCK)).

                     The format for this field was %lu before Linux 2.6.
```

But the starttime is relative to the kernel start time, which does not always match the result of `ProcessStart.get_boot_time`.

A simple solution might be to use the `mtime` of `/proc/pid` instead.  The `mtime` is set to the current wall clock time when the process is started, so it should be correct for every process except PID 1, where the correct time may not yet be known.

For https://issues.redhat.com/browse/RHEL-39775.