### PR TITLE
rhel-9.5: revert systemd boot time

### DIFF
--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -36,30 +36,30 @@ Description
 Note that in most cases a process should survive update of its binary and libraries it is using without requiring to be restarted for proper operation. There are however specific cases when this does not apply. Separately, processes often need to be restarted to reflect security updates.
 
 .. note::
-   Needs-restarting will try to guess the boot time using three different methods:
+   Needs restarting will try to guess the boot time using three different methods:
 
    ``UnitsLoadStartTimestamp``
-        D-Bus property on ``/org/freedesktop/systemd1``.
+        property on ``/org/freedesktop/systemd1``.
         Works unless the system was not booted with systemd,
         such as in (most) containers.
    ``st_mtime of /proc/1``
-        Reflects the time the first process was run after booting.
+        Reflects the time the first process was run after booting
         This works for all known cases except machines without
-        a RTC—they awake at the start of the epoch.
+        a RTC - they awake at the start of the epoch.
    ``/proc/uptime``
-        Seconds field of ``/proc/uptime`` subtracted from the current time.
+        Seconds field of /proc/uptime subtracted from the current time
         Works for machines without RTC if the current time is reasonably correct.
         Does not work on containers which share their kernel with the
-        host—there, the host kernel uptime is returned.
+        host - there the host kernel uptime is returned
 
 
 .. warning::
-    Some systems are configured to read the RTC time in the local time
-    zone. This mode cannot be fully supported. It will create various problems
-    with time zone changes and daylight saving time adjustments. The RTC time
-    is never updated, it relies on external facilities to maintain it. **If at
-    all possible, use RTC in UTC by calling** ``timedatectl set-local-rtc 0``.
-    See ``man timedatectl`` for more information.
+    When the system is configured to read the RTC time in the local time zone.
+    This mode cannot be fully supported. It will create various problems
+    with time zone changes and daylight saving time adjustments. The RTC
+    time is never updated, it relies on external facilities to maintain it.
+    **If at all possible, use RTC in UTC by calling**
+    ``timedatectl set-local-rtc 0``.
 
 -------
 Options

--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -35,32 +35,6 @@ Description
 
 Note that in most cases a process should survive update of its binary and libraries it is using without requiring to be restarted for proper operation. There are however specific cases when this does not apply. Separately, processes often need to be restarted to reflect security updates.
 
-.. note::
-   Needs restarting will try to guess the boot time using three different methods:
-
-   ``UnitsLoadStartTimestamp``
-        property on ``/org/freedesktop/systemd1``.
-        Works unless the system was not booted with systemd,
-        such as in (most) containers.
-   ``st_mtime of /proc/1``
-        Reflects the time the first process was run after booting
-        This works for all known cases except machines without
-        a RTC - they awake at the start of the epoch.
-   ``/proc/uptime``
-        Seconds field of /proc/uptime subtracted from the current time
-        Works for machines without RTC if the current time is reasonably correct.
-        Does not work on containers which share their kernel with the
-        host - there the host kernel uptime is returned
-
-
-.. warning::
-    When the system is configured to read the RTC time in the local time zone.
-    This mode cannot be fully supported. It will create various problems
-    with time zone changes and daylight saving time adjustments. The RTC
-    time is never updated, it relies on external facilities to maintain it.
-    **If at all possible, use RTC in UTC by calling**
-    ``timedatectl set-local-rtc 0``.
-
 -------
 Options
 -------

--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -215,11 +215,6 @@ class ProcessStart(object):
         We have two sources from which to derive the boot time. These values vary
         depending on containerization, existence of a Real Time Clock, etc.
         For our purposes we want the latest derived value.
-        - UnitsLoadStartTimestamp property on /org/freedesktop/systemd1
-             The start time of the service manager, according to systemd itself.
-             Seems to be more reliable than UserspaceTimestamp when the RTC is
-             in local time. Works unless the system was not booted with systemd,
-             such as in (most) containers.
         - st_mtime of /proc/1
              Reflects the time the first process was run after booting
              This works for all known cases except machines without
@@ -230,25 +225,6 @@ class ProcessStart(object):
              Does not work on containers which share their kernel with the
              host - there the host kernel uptime is returned
         """
-        units_load_start_timestamp = None
-        try:
-            bus = dbus.SystemBus()
-            systemd1 = bus.get_object(
-                'org.freedesktop.systemd1',
-                '/org/freedesktop/systemd1'
-            )
-            props = dbus.Interface(
-                systemd1,
-                dbus.PROPERTIES_IFACE
-            )
-            units_load_start_timestamp = props.Get(
-                'org.freedesktop.systemd1.Manager',
-                'UnitsLoadStartTimestamp'
-            )
-            if units_load_start_timestamp != 0:
-                return int(units_load_start_timestamp / (1000 * 1000))
-        except dbus.exceptions.DBusException as e:
-            logger.debug("D-Bus error getting boot time from systemd: {}".format(e))
 
         proc_1_boot_time = int(os.stat('/proc/1').st_mtime)
         if os.path.isfile('/proc/uptime'):


### PR DESCRIPTION
This revers rhel-9.5 commits:

486e9d4d7f03309f3eaf71e297ae956e18357bd8
a0ac8717219a1ec9f466162e87f40afa9aa65284
74de8fe84679e509b16ca1d3f12b7d292210ca27
Resolves: https://issues.redhat.com/browse/RHEL-39775

because it causes a regression.

@evan-goode, could you review this revert?