### PR TITLE
needs-restarting: detect packages providing NEED_REBOOT.

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -283,7 +283,7 @@ class NeedsRestartingCommand(dnf.cli.Command):
         if self.opts.reboothint:
             need_reboot = set()
             installed = self.base.sack.query().installed()
-            for pkg in installed.filter(name=NEED_REBOOT):
+            for pkg in installed.filter(provides=NEED_REBOOT):
                 if pkg.installtime > process_start.boot_time:
                     need_reboot.add(pkg.name)
             if need_reboot:


### PR DESCRIPTION
When setting the reboot hint, search for newly installed or updated packages that provide the package names listed in `NEED_REBOOT`. This allows the `needs-restarting` plugin to detect if any alternative kernels have been installed/updated since the system last booted.