### PR TITLE
expired-pgp-keys: Fix calling the hook at resolved time

### DIFF
--- a/plugins/expired-pgp-keys.py
+++ b/plugins/expired-pgp-keys.py
@@ -20,7 +20,7 @@ class ExpiredPGPKeys(dnf.Plugin):
         self.base = base
         self.cli = cli
 
-    def pre_transaction(self):
+    def resolved(self):
         if not self.base.conf.gpgcheck:
             return
 


### PR DESCRIPTION
Because gpg signatures of packages are checked before actually running the `plugins.pre_transaction` hook, we need to call it earlier.