### PR TITLE
doc: copr plugin does not respect IP family preference

### DIFF
--- a/doc/copr.rst
+++ b/doc/copr.rst
@@ -132,3 +132,10 @@ Examples
 
 ``copr search tests``
     Search for Copr projects named ``tests``.
+
+------------
+Known issues
+------------
+
+Copr plugin does not respect `-4` and `-6` options of `dnf` command when enabling a Copr
+respository. Users are advised to configure a global address preference in /etc/gai.conf.


### PR DESCRIPTION
It was pointed that "dnf -4 copr enable ..." performs IPv6 connections. The cause is that _download_repo() function used urllib.request.urlopen() instead of dnf.base.urlopen() on purpose: It needs to process an HTTP status code and a custom HTTP header.

Unfortunatelly urllib.request.urlopen() does not support specifying an address family preference.

A long term fix would be replacing urllib.request.urlopen() with a pycurl Python library (or less likely augment dnf/libdnf/librepo to expose an HTTP layer).

As a short gap solution, this patch documents this deficiency and points the user to a global address family setting.

https://bugzilla.redhat.com/show_bug.cgi?id=2303712