### PR TITLE
Add Amazon Linux to copr chroots

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -487,6 +487,8 @@ Bugzilla. In case of problems, contact the owner of this repository.
                 chroot = ("opensuse-tumbleweed-{}".format(distarch))
             else:
                 chroot = ("opensuse-leap-{0}-{1}".format(dist[1], distarch))
+        elif "Amazon Linux" in dist[0]:
+            chroot = "amazonlinux-{}-{}".format(dist[1], distarch if distarch else "x86_64")
         else:
             chroot = ("epel-{}-{}".format(dist[1].split(".", 1)[0], distarch if distarch else "x86_64"))
         return chroot


### PR DESCRIPTION
This fixes a bug on Amazon Linux 2023 that prevents COPR from enabling packages, even if they have been built using amazonlinux chroot:

https://github.com/amazonlinux/amazon-linux-2023/issues/643

Repro on an ec2 instance trying to enable [sklarsa/zfs-al2023](https://copr.fedorainfracloud.org/coprs/sklarsa/zfs-al2023):
```sudo dnf copr enable -y sklarsa/zfs-al2023
Enabling a Copr repository. Please note that this repository is not part
of the main distribution, and quality may vary.

The Fedora Project does not exercise any power over the contents of
this repository beyond the rules outlined in the Copr FAQ at
<https://docs.pagure.org/copr.copr/user_documentation.html#what-i-can-build-in-copr>,
and packages are not held to any quality or security level.

Please do not file bug reports about these packages in Fedora
Bugzilla. In case of problems, contact the owner of this repository.
Error: It wasn't possible to enable this project.
Repository 'epel-2023-x86_64' does not exist in project 'sklarsa/zfs-al2023'.
Available repositories: 'amazonlinux-2023-aarch64', 'amazonlinux-2023-x86_64'

If you want to enable a non-default repository, use the following command:
  'dnf copr enable sklarsa/zfs-al2023 <repository>'
But note that the installed repo file will likely need a manual modification.
```