### PR TITLE
needs-restarting: Add --exclude-services

### DIFF
--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -72,6 +72,9 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
 ``-s, --services``
     Only list the affected systemd services.
 
+``--exclude-services``
+    Don't list stale processes that correspond to a systemd service.
+
 -------------
 Configuration
 -------------


### PR DESCRIPTION
For consumers of `dnf4 needs-restarting`'s output, it's useful to separate the systemd services needing restart vs. the processes not managed by systemd that need restarting. This new `dnf4 needs-restarting --exclude-services` ONLY prints information about processes NOT managed by systemd, and for listing systemd services that need to be restarted, the existing `--services` flag can be used.

When both `--services` and `--exclude-services` are passed `--exclude-services` is ignored.

For https://issues.redhat.com/browse/RHEL-56137.

CI PR on the way.