### PR TITLE
bootc: Implement the 'install' subcommand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,9 @@ ELSE ()
     MESSAGE (FATAL_ERROR "Invalid PYTHON_DESIRED value: " ${PYTHON_DESIRED})
 ENDIF()
 
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from sysconfig import get_path; stdout.write(get_path('purelib'))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+IF (NOT PYTHON_INSTALL_DIR)
+    EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from sysconfig import get_path; stdout.write(get_path('purelib'))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+ENDIF()
 MESSAGE(STATUS "Python install dir is ${PYTHON_INSTALL_DIR}")
 
 SET (SYSCONFDIR /etc)

--- a/doc/bootc.rst
+++ b/doc/bootc.rst
@@ -8,7 +8,7 @@ Manipulate image mode based systems using RPMs available from dnf repositories.
 Synopsis
 --------
 
-``dnf bootc [status] <options>``
+``dnf bootc [status|install] <options>``
 
 -----------------
 Arguments (bootc)
@@ -16,6 +16,9 @@ Arguments (bootc)
 
 ``bootc status <options>``
     The status of the image mode system.
+
+``bootc install [options] <pkg-spec>...``
+    Install one or more packages.
 
 -------
 Options
@@ -33,7 +36,28 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
     Filter JSONPath expression (valid on the status subcommand).
 
 ``--pending-exit-77``
-    If pending deploymewnt available, exit 77 (valid on the status subcommand).
+    If pending deployment available, exit 77 (valid on the status subcommand).
+
+``--uninstall PKG...``
+    Remove overlayed additional package (valid on the install subcommand).
+
+``-A``, ``--apply-live``
+    Apply changes to both pending deployment and running filesystem tree (valid on the install subcommand).
+
+``--force-replacefiles``
+    Allow package to replace files from other packages (valid on the install subcommand).
+
+``-r``, ``--reboot``
+    Initiate a reboot after operation is complete (valid on the install subcommand).
+
+``--allow-inactive``
+    Allow inactive package requests (valid on the install subcommand).
+
+``--idempotent``
+    Do nothing if package already (un)installed (valid on the install subcommand).
+
+``--unchanged-exit-77``
+    If no overlays were changed, exit 77 (valid on the install subcommand).
 
 ``--peer``
-    Force a peer-to-peer connection instead of using the system message bus (valid on the status subcommand).
+    Force a peer-to-peer connection instead of using the system message bus (valid on the status and install subcommands).

--- a/doc/needs_restarting.rst
+++ b/doc/needs_restarting.rst
@@ -72,6 +72,9 @@ All general DNF options are accepted, see `Options` in :manpage:`dnf(8)` for det
 ``-s, --services``
     Only list the affected systemd services.
 
+``--exclude-services``
+    Don't list stale processes that correspond to a systemd service.
+
 -------------
 Configuration
 -------------

--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -487,6 +487,8 @@ Bugzilla. In case of problems, contact the owner of this repository.
                 chroot = ("opensuse-tumbleweed-{}".format(distarch))
             else:
                 chroot = ("opensuse-leap-{0}-{1}".format(dist[1], distarch))
+        elif "Amazon Linux" in dist[0]:
+            chroot = "amazonlinux-{}-{}".format(dist[1], distarch if distarch else "x86_64")
         else:
             chroot = ("epel-{}-{}".format(dist[1].split(".", 1)[0], distarch if distarch else "x86_64"))
         return chroot


### PR DESCRIPTION
Implement the 'install' subcommand for the bootc plugin and add documentation.  Most of the options for this subcommand will come from global dnf command line option settings.  The only option not handled is --os=OSNAME from rpm-ostree.

https://issues.redhat.com/browse/SWM-3090