### PR TITLE
needs-restarting: "Regular files" are often on 00:xx devices

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -170,9 +170,6 @@ def smap2opened_file(pid, line):
     slash = line.find('/')
     if slash < 0:
         return None
-    if line.find('00:') >= 0:
-        # not a regular file
-        return None
     fn = line[slash:].strip()
     suffix_index = fn.rfind(' (deleted)')
     if suffix_index < 0:

--- a/tests/test_needs_restarting.py
+++ b/tests/test_needs_restarting.py
@@ -28,15 +28,14 @@ import tempfile
 
 DEL_FILE = '3dcf000000-3dcf032000 r-xp 00000000 08:02 140759                ' \
            '         /usr/lib64/libXfont.so.1.4.1;5408628d (deleted)'
-MM_FILE = '7fc4e1168000-7fc4e1169000 rw-s 1096dd000 00:05 7749' \
-          '                      /dev/dri/card0'
+HEAP_FILE = '556d60d52000-556d60e1c000 rw-p 00000000 00:00 0                          [heap]'
 SO_FILE = '30efe06000-30efe07000 r--p 00006000 08:02 139936' \
           '                         /usr/lib64/libSM.so.6.0.1'
 class NeedsRestartingTest(tests.support.TestCase):
     def test_smap2opened_file(self):
         func = needs_restarting.smap2opened_file
         self.assertIsNone(func(1, 'Shared_Dirty:          0 kB'))
-        self.assertIsNone(func(1, MM_FILE))
+        self.assertIsNone(func(1, HEAP_FILE))
 
         ofile = func(5, SO_FILE)
         self.assertFalse(ofile.deleted)


### PR DESCRIPTION
needs-restarting currently checks the major:minor device of each mmapped file and ignores files from devices with major version 0, considering them "not regular files". According to the kernel docs [1], a major version of 0 is for "unnamed devices, e.g. non-device mounts".

But ignoring files on 00:xx devices seems to not be a valid strategy. From my testing, in containers and in virtual machines especially, "regular files" managed by DNF are often on these devices. For example:

```
docker run -it --rm fedora:40 stat /usr/bin/sleep
  File: /usr/bin/sleep
  Size: 36864     	Blocks: 72         IO Block: 4096   regular file
Device: 0,100	Inode: 2403790     Links: 1
...
```

This patch removes this filter so that we just check that a file has a corresponding file path. There are files that have (something that looks like) a file path but are not "regular files", for example:

```
7283/maps:7f7f3f0d2000-7f7f3f0e0000 rw-s 00000000 00:01 7224                       /memfd:mozilla-ipc (deleted)
```

We should be able to ignore these since they would not be in the RPM database anyway.

[1] https://www.kernel.org/doc/Documentation/admin-guide/devices.txt