### PR TITLE
rhel-9.6: Fix for RHEL-40914 (reposync: Respect --norepopath with --metadata-path)

### DIFF
--- a/plugins/reposync.py
+++ b/plugins/reposync.py
@@ -180,7 +180,7 @@ class RepoSyncCommand(dnf.cli.Command):
 
     def metadata_target(self, repo):
         if self.opts.metadata_path:
-            return _pkgdir(self.opts.metadata_path, repo.id)
+            return _pkgdir(self.opts.metadata_path, repo.id if not self.opts.norepopath else '')
         else:
             return self.repo_target(repo)
 


### PR DESCRIPTION
This is a backport for the commit https://github.com/rpm-software-management/dnf-plugins-core/commit/05706d097b30632b823bb619d9ba634297c82863 into the rhel-9.6 branch.

Resolves: https://issues.redhat.com/browse/RHEL-40914