### PR TITLE
spec: toggle dnf5_obsoletes_dnf for RHEL 11

### DIFF
--- a/dnf-plugins-core.spec
+++ b/dnf-plugins-core.spec
@@ -8,7 +8,7 @@
 
 %define __cmake_in_source_build 1
 
-%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 11]
+%bcond dnf5_obsoletes_dnf %[0%{?fedora} > 40 || 0%{?rhel} > 10]
 
 %if (0%{?fedora} && 0%{?fedora} >= 41) || (0%{?rhel} && 0%{?rhel} >= 10)
 %bcond_with debug_plugin


### PR DESCRIPTION
Fedora 41 has completed the migration to DNF5, so ELN (the future RHEL 11) is now ready to follow suit.

Related: https://github.com/rpm-software-management/dnf/pull/2161

/cc @evan-goode 