### PR TITLE
rhel-9.6: Fix for RHEL-56143

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -444,7 +444,7 @@ Bugzilla. In case of problems, contact the owner of this repository.
             dist = linux_distribution()
         # Get distribution architecture
         distarch = self.base.conf.substitutions['basearch']
-        if any([name in dist for name in ["Fedora", "Fedora Linux"]]):
+        if "Fedora" in dist[0]:
             if "Rawhide" in dist:
                 chroot = ("fedora-rawhide-" + distarch)
             # workaround for enabling repos in Rawhide when VERSION in os-release
@@ -470,7 +470,7 @@ Bugzilla. In case of problems, contact the owner of this repository.
             else:
                 chroot = ("opensuse-leap-{0}-{1}".format(dist[1], distarch))
         else:
-            chroot = ("epel-%s-x86_64" % dist[1].split(".", 1)[0])
+            chroot = ("epel-{}-{}".format(dist[1].split(".", 1)[0], distarch if distarch else "x86_64"))
         return chroot
 
     def _download_repo(self, project_name, repo_filename):


### PR DESCRIPTION
This is a backport of the upstream commit: https://github.com/rpm-software-management/dnf-plugins-core/commit/4c2b209d2367e48f8aeef18e9c696c42774cc6eb for rhel-9.6 branch.