### PR TITLE
README: direct to Libera.Chat instead of Freenode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,4 +95,4 @@ The DNF-PLUGINS-CORE package distribution contains man pages ``dnf.plugin.*(8)``
 
 Please report discovered bugs to the `Red Hat bugzilla <https://bugzilla.redhat.com/>`_ following this `guide <https://github.com/rpm-software-management/dnf/wiki/Bug-Reporting>`_. If you planned to propose the patch in the report, consider `contribution`_ instead.
 
-Freenode's irc channel ``#yum`` is meant for discussions related to both Yum and DNF. Questions should be asked there, issues discussed. Remember: ``#yum`` is not a support channel and prior research is expected from the questioner.
+Libera.Chat's IRC channel ``#yum`` is meant for discussions related to both YUM and DNF. Questions should be asked there, issues discussed. Remember: ``#yum`` is not a support channel, and prior research is expected from the questioner.


### PR DESCRIPTION
Companion to https://github.com/rpm-software-management/dnf/pull/2221. @ppisar 