### PR TITLE
README: link to #dnf instead of #yum IRC

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@
 
 Core plugins to use with `DNF package manager <https://github.com/rpm-software-management/dnf>`_.
 
+Join us on IRC at ``#dnf`` on `Libera.Chat <https://libera.chat>`_. Questions should be asked there, issues discussed. Remember: ``#dnf`` is not a support channel, and prior research is expected from the questioner.
+
 ==============
  Installation
 ==============
@@ -89,10 +91,8 @@ Please do not create pull requests with translation (.po) file improvements. Fix
 
 The DNF-PLUGINS-CORE package distribution contains man pages ``dnf.plugin.*(8)``. It is also possible to read the `DNF-PLUGINS-CORE documentation <http://dnf-plugins-core.readthedocs.org>`_ online.
 
-====================
- Bug reporting etc.
-====================
+===============
+ Bug reporting
+===============
 
-Please report discovered bugs to the `Red Hat bugzilla <https://bugzilla.redhat.com/>`_ following this `guide <https://github.com/rpm-software-management/dnf/wiki/Bug-Reporting>`_. If you planned to propose the patch in the report, consider `contribution`_ instead.
-
-Libera.Chat's IRC channel ``#yum`` is meant for discussions related to both YUM and DNF. Questions should be asked there, issues discussed. Remember: ``#yum`` is not a support channel, and prior research is expected from the questioner.
+Please report discovered bugs to `GitHub Issues <https://github.com/rpm-software-management/dnf-plugins-core/issues>`_ or to the `Red Hat bugzilla <https://bugzilla.redhat.com/>`_. If you plan to propose the patch in the report, consider `Contribution`_ instead.


### PR DESCRIPTION
dnf-plugins-core counterpart to https://github.com/rpm-software-management/dnf/pull/2232.

Move the message about IRC to the top of the README so it's more visible.

Remove dead link to the bug reporting guide.