### PR TITLE
copr: Respect releasever set in copr.conf

### DIFF
--- a/plugins/copr.py
+++ b/plugins/copr.py
@@ -459,8 +459,10 @@ Bugzilla. In case of problems, contact the owner of this repository.
         """ Guess which chroot is equivalent to this machine """
         # FIXME Copr should generate non-specific arch repo
         dist = self.chroot_config
+        dist_detected = False
         if dist is None or (dist[0] is False) or (dist[1] is False):
             dist = linux_distribution()
+            dist_detected = True
         # Get distribution architecture
         distarch = self.base.conf.substitutions['basearch']
         if "Fedora" in dist[0]:
@@ -468,7 +470,7 @@ Bugzilla. In case of problems, contact the owner of this repository.
                 chroot = ("fedora-rawhide-" + distarch)
             # workaround for enabling repos in Rawhide when VERSION in os-release
             # contains a name other than Rawhide
-            elif "rawhide" in os_release_attr("redhat_support_product_version"):
+            elif dist_detected and "rawhide" in os_release_attr("redhat_support_product_version"):
                 chroot = ("fedora-rawhide-" + distarch)
             else:
                 chroot = ("fedora-{0}-{1}".format(dist[1], distarch))


### PR DESCRIPTION
If the plugin was executed on Fedora Rawhide, Copr releasever was silently overriden to "rawhide" regardless of what was explicitly set in copr.conf. As a result, it was impossible to configure the plugin to use something else than fedora-rawhide chroot on those systems.

That manifested in ci-dnf-stack where "Test the COPR plugin" test (dnf/plugins-core/copr.feature:2) passed everywhere except of Rawhide.

This patch relaxes the override to be only applied when there is no explicit configuration in the plugin configuration. I.e. the override is now effective only when the Copr chroot is autodetected.

The override was orginally added because of
<https://bugzilla.redhat.com/show_bug.cgi?id=1628888>.

Resolve: #592