### PR TITLE
manifest: Adapt to RPM 6.0.0 beta

### DIFF
--- a/plugins/manifest.py
+++ b/plugins/manifest.py
@@ -448,8 +448,13 @@ class ManifestCommand(dnf.cli.Command):
     def _retrieve_pkg_checksum(self, pkg):
         if pkg._from_system:
             hdr = pkg.get_header()
-            method = self._rpm_checksum_type_to_manifest_conversion(hdr[rpm.RPMTAG_PAYLOADDIGESTALGO])
-            digest = hdr[rpm.RPMTAG_PAYLOADDIGEST][0]
+            if hasattr(rpm, 'RPMTAG_PAYLOADDIGESTALGO'):
+                # RPM < 6 compatibility
+                method = self._rpm_checksum_type_to_manifest_conversion(hdr[rpm.RPMTAG_PAYLOADDIGESTALGO])
+                digest = hdr[rpm.RPMTAG_PAYLOADDIGEST][0]
+            else:
+                method = self._rpm_checksum_type_to_manifest_conversion(hdr[rpm.RPMTAG_PAYLOADSHA256ALGO])
+                digest = hdr[rpm.RPMTAG_PAYLOADSHA256ALT][0]
         else:
             dnf_chksum_type, dnf_chksum_digest = pkg.chksum
             method = self._dnf_checksum_type_to_manifest_conversion(dnf_chksum_type)


### PR DESCRIPTION
Since RPM 6.0.0-beta manifest plugin fails like this:

        File "/usr/lib/python3.14/site-packages/dnf-plugins/manifest.py", line 116, in run
          self._new()
          ~~~~~~~~~^^
        File "/usr/lib/python3.14/site-packages/dnf-plugins/manifest.py", line 147, in _new
          self._add_packages_to_manifest(self._resolve_packages(), arch, manifest, modules_info)
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/lib/python3.14/site-packages/dnf-plugins/manifest.py", line 250, in _add_packages_to_manifest
          pkg.checksum.method, pkg.checksum.digest = self._retrieve_pkg_checksum(dnf_pkg)
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
        File "/usr/lib/python3.14/site-packages/dnf-plugins/manifest.py", line 451, in _retrieve_pkg_checksum
          method = self._rpm_checksum_type_to_manifest_conversion(hdr[rpm.RPMTAG_PAYLOADDIGESTALGO])
                                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'rpm' has no attribute 'RPMTAG_PAYLOADDIGESTALGO'. Did you mean: 'RPMTAG_FILEDIGESTALGO'?

The cause is that RPM commit f14557cd521ddf95994aa6518f006eeb3fc58d87 (Rename PAYLOADDIGEST tags to PAYLOADSHA256 to match reality) renamed RPMTAG_PAYLOADDIGESTALGO and RPMTAG_PAYLOADDIGESTALT tags.

This patch fixes it by using the new identifiers and using the old ones only if they are defined.