### PR TITLE
tito.props: Add test_version_suffix = ^9999

### DIFF
--- a/.tito/tito.props
+++ b/.tito/tito.props
@@ -3,3 +3,4 @@ builder = tito.builder.Builder
 tagger = tito.tagger.VersionTagger
 changelog_do_not_remove_cherrypick = 0
 changelog_format = %s (%ae)
+test_version_suffix = ^9999


### PR DESCRIPTION
The caret symbol (‘^’) is used before a version component which must sort later than any non-caret component. It's especially useful here to ensure that development builds of the rhel-x.y branches (which always stay at Release: 1) are sorter higher than the builds in CentOS/RHEL repositories (whose Release is continually incremented).

For example, if `dnf` build from c10s, rhel-10-main, or the upstream rhel-10.2 branch of dnf requires libdnf >= 0.73.1-7, then it's convenient if our upstream libdnf rhel-10.2 builds satisfy that requirement, e.g. by having version 0.73.1-1^9999.

dnf-plugins-core companion to https://github.com/rpm-software-management/libdnf/pull/1769.