### PR TITLE
Fix for issue #617, incorrect parsing of /proc/PID/stat

### DIFF
--- a/plugins/needs_restarting.py
+++ b/plugins/needs_restarting.py
@@ -300,8 +300,15 @@ class ProcessStart(object):
     def __call__(self, pid):
         stat_fn = '/proc/%d/stat' % pid
         with open(stat_fn) as stat_file:
-            stats = stat_file.read().split()
-        ticks_after_kernel_boot = int(stats[21])
+            stats_line = stat_file.read();
+            # Second field is a parens enclosed name which might include spaces
+            name_end = stats_line.find(')')
+            if name_end < 0:
+                logger.warning("PID %s's stat line missing expected parenthesis ", pid)
+                return self.kernel_boot_time
+            stats_line = stats_line[name_end+1:]
+            stats = stats_line.split()
+        ticks_after_kernel_boot = int(stats[19])
         secs_after_kernel_boot = ticks_after_kernel_boot / self.sc_clk_tck
 
         # The process's start time is always measured relative to the kernel


### PR DESCRIPTION
Fix for issue #617 to correctly parse /proc/PID/stat for cases where process names have a space.  The proc_pid_stat man page clearly states that the command name field is in parenthesis, and I've confirmed that this was true back to some ancient versions of the kernel (2.6 series), but the kernel source would give the true time (if it ever was anything different).

Confirmed working on an RHEL 9 based system with the shipping needs-restarting plugin in that, patched into same portion of master repo.